### PR TITLE
Removed PrivatiserLevelAdd and unified with PrivatiserLevel

### DIFF
--- a/rules/src/main/scala/scalaclean/privatiser/PrivatiserLevel.scala
+++ b/rules/src/main/scala/scalaclean/privatiser/PrivatiserLevel.scala
@@ -6,15 +6,17 @@ import scalafix.v1.Symbol
 private[privatiser] sealed trait PrivatiserLevel extends Colour {
   def keyword: Option[String] = None
   def reason: String
+  def scope: Symbol
+
   def combine(level: PrivatiserLevel): PrivatiserLevel
 }
 
-private[privatiser] case object Public extends PrivatiserLevel {
+private[privatiser] case class Public(scope: Symbol) extends PrivatiserLevel {
   def reason = "initial assumption: symbol should be public"
   def combine(level: PrivatiserLevel): PrivatiserLevel = level
 }
 
-private[privatiser] case class NoChange(reason: String) extends PrivatiserLevel {
+private[privatiser] case class NoChange(scope: Symbol, reason: String) extends PrivatiserLevel {
   def combine(level: PrivatiserLevel): PrivatiserLevel = this
 }
 

--- a/rules/src/main/scala/scalaclean/privatiser/ScalaCleanPrivatiserApply.scala
+++ b/rules/src/main/scala/scalaclean/privatiser/ScalaCleanPrivatiserApply.scala
@@ -32,11 +32,11 @@ class ScalaCleanPrivatiserApply extends SemanticRule("ScalaCleanPrivatiserApply"
     }.toSet - element
     println(s"Privatiser for $element START - process ${element.internalIncomingReferences}")
 
-    var res: PrivatiserLevel = Public
+    var res: PrivatiserLevel = Public(element.symbol)
     //is it defined by the signature
     element match {
       case o: ObjectModel if o.xtends[App] =>
-        res.combine(NoChange("its an App and needs to be public"))
+        res.combine(NoChange(element.symbol, "its an App and needs to be public"))
       //      case any: ModelElement if any.hasAnnotation[ExternalAccess] => Some(NoChange(any.getAnnotation[ExternalAccess]))
       //      case method:MethodModel if (method.overidesExternal)=>  res.combine(Level of parent method)
       //probably other cases
@@ -69,8 +69,8 @@ class ScalaCleanPrivatiserApply extends SemanticRule("ScalaCleanPrivatiserApply"
         val prepared = model.fromSymbol[ObjectModel](obj.symbol)
         val change = prepared.colour.asInstanceOf[PrivatiserLevel]
         change match {
-          case NoChange(_) => (Patch.empty, true)
-          case Public => throw new IllegalStateException("Trying to make something public, something went terribly wrong here!")
+          case NoChange(_, _) => (Patch.empty, true)
+          case Public(_) => throw new IllegalStateException("Trying to make something public, something went terribly wrong here!")
           case level: PrivatiserLevel => changeAccessModifier(level)
         }
       }
@@ -79,7 +79,10 @@ class ScalaCleanPrivatiserApply extends SemanticRule("ScalaCleanPrivatiserApply"
     Patch.empty
   }
 
-  private def changeAccessModifier(level: PrivatiserLevel): (Patch, Boolean) =
+  private def changeAccessModifier(level: PrivatiserLevel): (Patch, Boolean) = {
+    val symbol = level
+
     // TODO -- change me
     (Patch.empty, true)
+  }
 }

--- a/rules/src/main/scala/scalaclean/privatiser/ScalaCleanPrivatiserApply.scala
+++ b/rules/src/main/scala/scalaclean/privatiser/ScalaCleanPrivatiserApply.scala
@@ -32,7 +32,7 @@ class ScalaCleanPrivatiserApply extends SemanticRule("ScalaCleanPrivatiserApply"
     }.toSet - element
     println(s"Privatiser for $element START - process ${element.internalIncomingReferences}")
 
-    var res: PrivatiserLevel = Initial
+    var res: PrivatiserLevel = Public
     //is it defined by the signature
     element match {
       case o: ObjectModel if o.xtends[App] =>
@@ -69,20 +69,17 @@ class ScalaCleanPrivatiserApply extends SemanticRule("ScalaCleanPrivatiserApply"
         val prepared = model.fromSymbol[ObjectModel](obj.symbol)
         val change = prepared.colour.asInstanceOf[PrivatiserLevel]
         change match {
-          case NoChange(reason) =>
-            (Patch.empty, true)
-          case Private(scope, reason) =>
-            //TODO -- change me
-            (Patch.empty, true)
-          case Protected(scope, reason) =>
-            // TODO -- change me
-            (Patch.empty, true)
-          case Initial =>
-            throw new IllegalStateException("Found an Initial level, something went terribly wrong!")
+          case NoChange(_) => (Patch.empty, true)
+          case Public => throw new IllegalStateException("Trying to make something public, something went terribly wrong here!")
+          case level: PrivatiserLevel => changeAccessModifier(level)
         }
       }
     }
     tv.visitDocument(doc.tree)
     Patch.empty
   }
+
+  private def changeAccessModifier(level: PrivatiserLevel): (Patch, Boolean) =
+    // TODO -- change me
+    (Patch.empty, true)
 }


### PR DESCRIPTION
Simplifying model: 
- PrivatiserLevelAdd has been removed
- `Initial` is now `Public`: initially, we just assume that something should be public.