### PR TITLE
SCComponent: Avoid NPE finding ValDef's ModelFields

### DIFF
--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCompilerPluginComponent.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCompilerPluginComponent.scala
@@ -492,7 +492,7 @@ class ScalaCompilerPluginComponent(
           val isVar = symbol.isVar
           val fields: Option[ModelFields] = valDef.rhs match {
              case Select(qualifier, name) =>
-               qualifier.symbol.attachments.get[ModelFields]
+               Option(qualifier.symbol).flatMap(_.attachments.get[ModelFields])
              case _ => None
            }
 


### PR DESCRIPTION
    [error] ## Exception when compiling 81 sources to /d/kentuckymule/kentuckymule/target/scala-2.12/classes
    [error] java.lang.NullPointerException
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:495)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:221)
    [error] scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$2(Trees.scala:2506)
    [error] scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2515)
    [error] scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$1(Trees.scala:2506)
    [error] scala.reflect.api.Trees$Traverser.traverseStats(Trees.scala:2505)
    [error] scala.reflect.internal.Trees.traverseComponents$1(Trees.scala:1270)
    [error] scala.reflect.internal.Trees.itraverse(Trees.scala:1368)
    [error] scala.reflect.internal.Trees.itraverse$(Trees.scala:1238)
    [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:28)
    [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:28)
    [error] scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2483)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.super$traverse(ScalaCompilerPluginComponent.scala:384)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.$anonfun$traverse$4(ScalaCompilerPluginComponent.scala:399)
    [error] scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterTransScope(ScalaCompilerPluginComponent.scala:215)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterTransScope$(ScalaCompilerPluginComponent.scala:207)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.enterTransScope(ScalaCompilerPluginComponent.scala:221)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:397)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:221)
    [error] scala.reflect.internal.Trees.$anonfun$itraverse$1(Trees.scala:1246)
    [error] scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2515)
    [error] scala.reflect.internal.Trees.traverseMemberDef$1(Trees.scala:1241)
    [error] scala.reflect.internal.Trees.itraverse(Trees.scala:1365)
    [error] scala.reflect.internal.Trees.itraverse$(Trees.scala:1238)
    [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:28)
    [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:28)
    [error] scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2483)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.super$traverse(ScalaCompilerPluginComponent.scala:384)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.$anonfun$traverse$12(ScalaCompilerPluginComponent.scala:449)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.$anonfun$traverse$12$adapted(ScalaCompilerPluginComponent.scala:438)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterScope(ScalaCompilerPluginComponent.scala:190)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterScope$(ScalaCompilerPluginComponent.scala:168)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.enterScope(ScalaCompilerPluginComponent.scala:221)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:438)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:221)
    [error] scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$2(Trees.scala:2506)
    [error] scala.reflect.api.Trees$Traverser.atOwner(Trees.scala:2515)
    [error] scala.reflect.api.Trees$Traverser.$anonfun$traverseStats$1(Trees.scala:2506)
    [error] scala.reflect.api.Trees$Traverser.traverseStats(Trees.scala:2505)
    [error] scala.reflect.internal.Trees.itraverse(Trees.scala:1364)
    [error] scala.reflect.internal.Trees.itraverse$(Trees.scala:1238)
    [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:28)
    [error] scala.reflect.internal.SymbolTable.itraverse(SymbolTable.scala:28)
    [error] scala.reflect.api.Trees$Traverser.traverse(Trees.scala:2483)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.super$traverse(ScalaCompilerPluginComponent.scala:384)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.$anonfun$traverse$1(ScalaCompilerPluginComponent.scala:384)
    [error] scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterTransScope(ScalaCompilerPluginComponent.scala:215)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterTransScope$(ScalaCompilerPluginComponent.scala:207)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.enterTransScope(ScalaCompilerPluginComponent.scala:221)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverse(ScalaCompilerPluginComponent.scala:382)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.$anonfun$traverseSource$1(ScalaCompilerPluginComponent.scala:242)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.$anonfun$traverseSource$1$adapted(ScalaCompilerPluginComponent.scala:241)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterScope(ScalaCompilerPluginComponent.scala:190)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$ScopeTracking.enterScope$(ScalaCompilerPluginComponent.scala:168)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.enterScope(ScalaCompilerPluginComponent.scala:221)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$SCUnitTraverser.traverseSource(ScalaCompilerPluginComponent.scala:241)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$$anon$1.apply(ScalaCompilerPluginComponent.scala:142)
    [error] scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:453)
    [error] scala.tools.nsc.Global$GlobalPhase.run(Global.scala:399)
    [error] org.scalaclean.analysis.ScalaCompilerPluginComponent$$anon$1.run(ScalaCompilerPluginComponent.scala:80)
    [error] scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1503)
    [error] scala.tools.nsc.Global$Run.compileUnits(Global.scala:1487)
    [error] scala.tools.nsc.Global$Run.compileSources(Global.scala:1480)
    [error] scala.tools.nsc.Global$Run.compile(Global.scala:1606)