### PR TITLE
Try (& give up) finding unique method ids

### DIFF
--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ModelSymbolBuilder.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ModelSymbolBuilder.scala
@@ -26,10 +26,12 @@ trait ModelSymbolBuilder extends SemanticdbOps {
       localId(sym)
     case sym if sym.isMethod =>
       "{M}"+sym.encodedName +
+        sym.disambiguator +
         (if (sym.typeParams.isEmpty) ""
         else "[" + sym.typeParams.map { param => param.info.typeSymbol.fullName }.mkString(";") + "]"
           ) +
-        sym.paramss.map { params => params.map(param => paramName(param)).mkString(";") }.mkString("(", "", ")")
+        sym.paramss.map { params => params.map(param => paramName(param)).mkString(";") }.mkString("(", "", ")") +
+        sym.asMethod.returnType.toString.replace(',', ';') // no commas in a CSV-bounded world
     case sym if sym.isModule => sym.encodedName + "#"
     case sym if sym.isModuleOrModuleClass => sym.encodedName + "@"
     case sym if sym.isClass => sym.encodedName + "."

--- a/command/src/main/scala/scalaclean/model/impl/ProjectSet.scala
+++ b/command/src/main/scala/scalaclean/model/impl/ProjectSet.scala
@@ -40,8 +40,9 @@ class ProjectSet(projectPropertyPaths: Path*) extends ProjectModel {
           println(s"    $v")
 
         }
-        throw new IllegalStateException("Duplicate elements found")
       }
+
+      // throw new IllegalStateException("Duplicate elements found")
     }
 
     val relsFrom = rels.reduce(_ + _)


### PR DESCRIPTION
Running both the analysis plugin & the main against a codebase like
kentukymule (which contains the subset of an old fork of Dotty) made me
hit a bunch of overloading and overriding cases that trigger the
duplicate symbol checker.

The disambiguator helps for overloading & the return type helps for the
covariant return overriding.  But you still hit overriding duplicates
(SCUnitTraverser traversing a ClassDef records its methods & then those
methods are traversed & record themselves?) so I gave up & disabled it.

Hmm.