### PR TITLE
#1 - configure git to use LF only

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Autodetect text files
+* text=auto
+
+# ...Unless the name matches the following
+# overriding patterns
+
+# Definitively text files
+*.txt text
+*.scala text
+*.expected text
+
+# Ensure those won't be messed up with
+*.jpg binary
+*.data binary

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.DS_Store
 *.generated
 *.log
+*.semanticdb
 .idea/
 input/target/
 output/target/


### PR DESCRIPTION
Some tests rely on position info. 
Although ScalaClean itself should not care, the tests need the absolute information, so easier to force everything to be LF only