### PR TITLE
Next. Migrate the final patching from Semantic Document

### DIFF
--- a/command/src/main/scala/scalaclean/fix/ElementAction.scala
+++ b/command/src/main/scala/scalaclean/fix/ElementAction.scala
@@ -1,0 +1,3 @@
+package scalaclean.fix
+
+case class ElementAction(change: SourceChange, visitChildren: Boolean)

--- a/command/src/main/scala/scalaclean/fix/NewTreeVisitor.scala
+++ b/command/src/main/scala/scalaclean/fix/NewTreeVisitor.scala
@@ -1,0 +1,65 @@
+package scalaclean.fix
+
+import scalaclean.model._
+import scalaclean.model.impl.SourceModelImpl
+import scalafix.patch.Patch
+import scalafix.v1.SyntacticDocument
+
+import scala.collection.immutable
+import scala.meta.tokens.Token
+
+object NewTreeVisitor {
+  val continue: (Patch, Boolean) = (Patch.empty, true)
+  val skip: (Patch, Boolean) = (Patch.empty, false)
+}
+
+abstract class NewTreeVisitor {
+  private var _source:SourceModelImpl = _
+  private var _doc: SyntacticDocument = _
+  def tokensWithin(modelElement: ModelElement): immutable.IndexedSeq[Token] = {
+    syntacticDocument.tokens.filter{
+      token => token.start >= modelElement.rawStart && token.end <= modelElement.rawEnd
+    }
+  }
+
+
+  protected final def syntacticDocument: SyntacticDocument = {
+    import scala.meta.inputs.Input
+    if (_doc == null) {
+      val input = Input.File(_source.filename)
+      SyntacticDocument.fromInput(input)
+    }
+    _doc
+  }
+  protected final def source: SourceModel = _source
+
+  protected final def continue: (Patch, Boolean) = NewTreeVisitor.continue
+  protected final def skip: (Patch, Boolean) = NewTreeVisitor.skip
+
+  final def visitSourceFile(source: SourceModelImpl): Patch = {
+    this._source = source
+    val patch = handle(source, visitElement(source))
+    this._source = null
+    this._doc = null
+    afterSource()
+    patch
+  }
+
+  private def visitChildren(e: ModelElement): Patch = {
+    e.directChildren.foldLeft(Patch.empty) {
+      case (patch, child) =>
+        patch + handle(child, visitElement(child))
+    }
+  }
+
+  private def handle(e: ModelElement, handleRes: (Patch, Boolean)): Patch = {
+    val (patch, traverseChildren) = handleRes
+    if (traverseChildren)
+      patch + visitChildren(e)
+    else
+      patch
+  }
+
+  protected def afterSource() = {}
+  protected def visitElement(element: ModelElement): (Patch, Boolean)
+}

--- a/command/src/main/scala/scalaclean/fix/SourceChange.scala
+++ b/command/src/main/scala/scalaclean/fix/SourceChange.scala
@@ -1,0 +1,41 @@
+package scalaclean.fix
+
+import scala.collection.immutable.TreeSet
+import scala.meta.tokens.Token
+
+object SourceChange {
+  val none: SourceChange = SourceChanges(TreeSet.empty[Replace])
+  def replaceTokens(tokens: Seq[Token],replacement: String, comment: String ): SourceChange = {
+    assert (tokens.groupBy(_.input).size <= 1)
+    val sorted = tokens.sortBy(_.start)
+    sorted.grouped(2).foreach{
+      case Seq(t1, t2) => assert(t2.start == t1.end)
+    }
+    Replace(sorted.head.start, sorted.last.end, replacement, comment)
+  }
+  def removeTokens(tokens: Seq[Token], comment: String ): SourceChange = {
+    replaceTokens(tokens, "", comment)
+  }
+  def insertBefore(token: Token, text: String, comment: String ): SourceChange = {
+    Replace(token.start,token.start, text, comment)
+  }
+
+  private final case class SourceChanges(changes: TreeSet[Replace]) extends SourceChange {
+    override def +(change: SourceChange): SourceChange = change match {
+      case SourceChanges(otherChanges) => SourceChanges(this.changes ++ otherChanges)
+      case change: Replace =>SourceChanges(this.changes + change)
+    }
+  }
+  private final case class Replace(start: Int, end:Int, replace: String, comment: String) extends SourceChange with Ordered[Replace] {
+    override def +(change: SourceChange): SourceChange = change match {
+      case SourceChanges(otherChanges) => SourceChanges(otherChanges + this)
+      case change: Replace =>SourceChanges(TreeSet(this,change))
+    }
+
+    override def compare(that: Replace): Int = this.start - that.start
+  }
+}
+sealed trait SourceChange {
+  def + (change: SourceChange): SourceChange
+}
+

--- a/command/src/main/scala/scalaclean/model/impl/Project.scala
+++ b/command/src/main/scala/scalaclean/model/impl/Project.scala
@@ -42,25 +42,34 @@ object Project {
 class Project private(
                        val projects: ProjectSet, val classPath: Classpath, val outputPath: String, val src: String, val srcRoots: List[AbsolutePath], val srcBuildBase: String,
                        elementsFilePath: String, relationshipsFilePath: String, extensionsFilePath: String,
-                       val srcFiles: Set[String]) {
+                       @deprecated val srcFiles: Set[String]) {
+  @deprecated //probably
   def symbolTable: SymbolTable = GlobalSymbolTable(classPath, includeJdk = true)
 
+  @deprecated //probably
   lazy val classloader: ClassLoader = new URLClassLoader(Array(new URL("file:" + outputPath + "/")), null)
 
+  @deprecated
   private val infos = new ConcurrentHashMap[LegacyElementId, SymbolInformation]()
 
+  @deprecated
   def symbolInfo(viewedFrom: ElementModelImpl, symbol: LegacyElementId): SymbolInformation = {
     infos.computeIfAbsent(symbol,
       s => //any doc in the project would do though
         viewedFrom.source.doc.info(s.symbol).orNull)
   }
 
-  def read: (Vector[ElementModelImpl], BasicRelationshipInfo) = ModelReader.read(this, elementsFilePath, relationshipsFilePath, extensionsFilePath)
+  private[impl] def read: (Vector[ElementModelImpl], BasicRelationshipInfo) = ModelReader.read(this, elementsFilePath, relationshipsFilePath, extensionsFilePath)
 
   private val sourcesMap = new ConcurrentHashMap[String, SourceData]()
 
-  def source(name: String): SourceData = {
+  private[impl] def source(name: String): SourceData = {
     sourcesMap.computeIfAbsent(name, p => SourceData(this, Paths.get(p)))
+  }
+
+  lazy val sources:List[SourceModelImpl] = {
+    val impl = projects.allOf[SourceModelImpl].filter{_.info.source.project == this}.toList
+    impl.sortBy(_.filename.toString)
   }
 
 }

--- a/command/src/main/scala/scalaclean/rules/AbstractRule.scala
+++ b/command/src/main/scala/scalaclean/rules/AbstractRule.scala
@@ -1,10 +1,14 @@
 package scalaclean.rules
 
+import com.sun.media.sound.ModelSource
+import scalaclean.fix.NewTreeVisitor
 import scalaclean.model._
 import scalafix.patch.Patch
 import scalafix.v1.SemanticDocument
 
 abstract class AbstractRule(val name: String, val model: ProjectModel, debug: Boolean) {
+  val isLegacy: Boolean
+
   def printSummary(): Unit
 
   type Colour <: Mark
@@ -31,6 +35,7 @@ abstract class AbstractRule(val name: String, val model: ProjectModel, debug: Bo
   def runRule(): Unit
 
   def fix(implicit doc: SemanticDocument): Patch
+  val patcher: NewTreeVisitor
 
   def markAll[T <: ModelElement : Manifest](colour: => Colour): Unit = {
     model.allOf[T].foreach {

--- a/command/src/main/scala/scalaclean/rules/privatiser/Privatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/Privatiser.scala
@@ -1,5 +1,6 @@
 package scalaclean.rules.privatiser
 
+import scalaclean.fix.NewTreeVisitor
 import scalaclean.model._
 import scalaclean.model.impl.LegacyElementId
 import scalaclean.rules.AbstractRule
@@ -262,4 +263,7 @@ class Privatiser(model: ProjectModel, debug: Boolean) extends AbstractRule("Priv
 
     tv.visitDocument(doc.tree)
   }
+
+  override val isLegacy: Boolean = true
+  override val patcher: NewTreeVisitor = null
 }

--- a/command/src/main/scala/scalaclean/util/FileUtils.scala
+++ b/command/src/main/scala/scalaclean/util/FileUtils.scala
@@ -1,0 +1,9 @@
+package scalaclean.util
+
+import java.nio.charset.{Charset, StandardCharsets}
+import java.nio.file.{Files, Path}
+
+object FileUtils {
+  def readAllBytes(path: Path): String = new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
+
+}

--- a/command/src/main/scala/scalafix/scalaclean/FixUtils.scala
+++ b/command/src/main/scala/scalafix/scalaclean/FixUtils.scala
@@ -7,9 +7,9 @@ import scalafix.v1.{SemanticDocument, SyntacticDocument}
 import scala.meta.internal.semanticdb.TextDocuments
 import scala.meta.internal.symtab.SymbolTable
 import scala.meta.io.RelativePath
-
+@deprecated
 object FixUtils {
-
+@deprecated
   private[scalafix] def fromPath(
                                   doc: SyntacticDocument,
                                   path: RelativePath,

--- a/command/src/main/scala/scalafix/scalaclean/cli/DocHelper.scala
+++ b/command/src/main/scala/scalafix/scalaclean/cli/DocHelper.scala
@@ -11,7 +11,9 @@ import scala.meta.inputs.Input
 import scala.meta.internal.io.FileIO
 import scala.meta.internal.symtab.SymbolTable
 
+@deprecated
 object DocHelper {
+  @deprecated
   def readSemanticDoc(
                        classLoader: ClassLoader,
                        symtab: SymbolTable,


### PR DESCRIPTION
use internal traverser ( SemanticDoc and our differ in structure)
lose references to SemanticDocument