### PR TITLE
rework the way that colours are managed

### DIFF
--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/AnalysisModel.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/AnalysisModel.scala
@@ -227,7 +227,7 @@ sealed trait ClassLike extends ModelSymbol {
    */
   val remainingChildOverrides: mutable.Map[Global#Symbol, mutable.Set[Global#Symbol]] = new mutable.HashMap
 
-  def removeChildOveride(child: Global#Symbol) = {
+  def removeChildOverride(child: Global#Symbol): Option[mutable.Set[Global#Symbol]] = {
     remainingChildOverrides.remove(child)
   }
 

--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCompilerPluginComponent.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCompilerPluginComponent.scala
@@ -278,7 +278,7 @@ class ScalaCompilerPluginComponent(val global: Global) extends PluginComponent w
       val sourceFile    = unit.source.file.file.toPath
       val sourceFileStr = sourceFile.toString
       val sourceSymbol =
-        ModelSource(unit.body, ModelCommon(true, elementIdManager(sourceFile), sourceFileStr, -1, -1, -1, "<NA>"))
+        ModelSource(unit.body, ModelCommon(isGlobal = true, elementIdManager(sourceFile), sourceFileStr, -1, -1, -1, "<NA>"))
       enterScope(sourceSymbol)(_ => traverse(unit.body))
 
       if (debug) {
@@ -573,8 +573,8 @@ class ScalaCompilerPluginComponent(val global: Global) extends PluginComponent w
                     ModelGetterMethod(
                       DefDef(getter, new Modifiers(getter.flags, newTermName(""), Nil), global.EmptyTree),
                       getterSym,
-                      false,
-                      false
+                      isTyped = false,
+                      isAbstract = false
                     )
                   ) { method =>
                     method.addGetterFor(field.common)
@@ -680,8 +680,8 @@ class ScalaCompilerPluginComponent(val global: Global) extends PluginComponent w
               val symbolAliases: List[Symbol] = {
                 for (params <- symbol.paramss;
                      param <- params;
-                     field = symbol.enclClass.tpe.decl(param.name);
-                //its a value, and the positions overlap
+                     field = symbol.enclClass.tpe.decl(param.name)
+                     //its a value, and the positions overlap
                      if field.isValue && field.pos.start <= param.pos.`end` && field.pos.`end` >= param.pos.start;
                      model <- cls.findChildBySymbol(field)) yield {
                   addAlias(param, model)
@@ -734,7 +734,7 @@ class ScalaCompilerPluginComponent(val global: Global) extends PluginComponent w
       case clsDirectParent: ClassLike =>
         val classSym = symbol.owner
 
-        val directSymbols: Set[global.Symbol] = clsDirectParent.removeChildOveride(symbol) match {
+        val directSymbols: Set[global.Symbol] = clsDirectParent.removeChildOverride(symbol) match {
           case None => Set()
           case Some(syms) =>
             syms.asInstanceOf[mutable.Set[global.Symbol]].toSet

--- a/command/src/main/scala/scalaclean/model/Mark.scala
+++ b/command/src/main/scala/scalaclean/model/Mark.scala
@@ -1,3 +1,67 @@
 package scalaclean.model
 
-trait Mark
+import scalaclean.model.Mark.NoChange
+
+object Mark {
+  def dontChange[T <: SomeSpecificColour](reason: DontChange): Mark[T] =
+    new NoChange[T](Set(reason))
+  def specific[T <: SomeSpecificColour](specific: T) : Mark[T] =
+    new Specific[T](specific)
+
+  private object _initial extends Mark[SomeSpecificColour] {
+    override def isInitial: Boolean = true
+
+    override def toString: String = "Mark:initial"
+  }
+  def initial[T <: SomeSpecificColour] = _initial.asInstanceOf[Mark[_]].asInstanceOf[Mark[T]]
+  private class Specific[T <: SomeSpecificColour](value: T) extends Mark[T] {
+    override val specific: Option[T] = Some(value)
+    override def toString: String = s"Mark:specific[${specific.get}]"
+  }
+  private class NoChange[T <: SomeSpecificColour](override val changeInhibitors: Set[DontChange]) extends Mark[T] {
+    override def specific: Option[T] = None
+    override def toString: String = s"Mark:no-change[$changeInhibitors]"
+  }
+  val maxChangeReasons = 1
+}
+sealed abstract class Mark[T <: SomeSpecificColour] {
+  def isInitial: Boolean = false
+  def specific: Option[T] = None
+  def changesAreBanned = changeInhibitors.nonEmpty
+  def changeInhibitors: Set[DontChange] = Set.empty
+  type colour = T
+
+  final def merge(other: Mark[T]): Mark[T] = {
+    if (isInitial) other
+    else if (changesAreBanned)
+      if (changeInhibitors.size >= Mark.maxChangeReasons) this
+      else if (other.changeInhibitors.subsetOf(this.changeInhibitors)) this
+      else if (this.changeInhibitors.subsetOf(other.changeInhibitors)) other
+      else new NoChange[T]((changeInhibitors ++ other.changeInhibitors).take(Mark.maxChangeReasons))
+    else if (other.changesAreBanned) other
+    else {
+      //both are specific
+      val thisS = specific.get
+      val otherS = other.specific.get.asInstanceOf[thisS.RealType]
+      val combined = (thisS merge otherS).asInstanceOf[T]
+      if (combined eq thisS) this
+      else if (combined eq otherS) other
+      else new Mark.Specific[T](combined)
+    }
+  }
+
+  final def banChange(reason: DontChange): Mark[T] = {
+    if (changeInhibitors.size >= Mark.maxChangeReasons || changeInhibitors.contains(reason)) this
+    else new NoChange[T](changeInhibitors + reason)
+  }
+  final def withSpecific(reason: T): Mark[T] = {
+    if (changesAreBanned) this
+    else new Mark.Specific(reason)
+  }
+}
+trait SomeSpecificColour {
+  type RealType <: SomeSpecificColour
+  def merge(other: RealType): RealType
+}
+trait DontChange
+case class SimpleReason(comment: String) extends DontChange

--- a/command/src/main/scala/scalaclean/model/Model.scala
+++ b/command/src/main/scala/scalaclean/model/Model.scala
@@ -15,7 +15,16 @@ sealed trait ModelElement extends Ordered[ModelElement] {
 
   def modelElementId: ElementId
 
-  var mark: Mark = _
+  var _mark: Mark[_] = null
+  def mark = _mark
+  def mark_=[T <: SomeSpecificColour](newMark: Mark[T]): Unit = {
+    if (_mark eq null)
+      _mark = newMark
+    else {
+      assert (!newMark.isInitial)
+      _mark = _mark.asInstanceOf[Mark[T]].merge(newMark)
+    }
+  }
 
   def name: String
 
@@ -341,7 +350,7 @@ private[model] object InternalFilters {
     override def apply(direct: Boolean, clazz: ClassLike): Boolean                                 = true
   }
 
-  object OnlyDirect extends Function1[Extends, Boolean] {
+  object OnlyDirect extends ((Extends) => Boolean) {
     override def apply(ex: Extends): Boolean = ex.isDirect
   }
 

--- a/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
@@ -25,14 +25,14 @@ class SimplePrivatiser(options: SimplePrivatiserCommandLine, model: ProjectModel
   override def ruleSpecific(): Unit = {
     model.allOf[ModelElement].foreach {
       case e if isOverridden(e) =>
-        e.colour = NoChange(s"It's overridden ${e.internalTransitiveOverriddenBy.head}")
+        e.colour = dontChange(s"It's overridden ${e.internalTransitiveOverriddenBy.head}")
       case e if isOverrides(e) =>
-        e.colour = NoChange(s"It overrides ${e.allTransitiveOverrides.head}")
+        e.colour = dontChange(s"It overrides ${e.allTransitiveOverrides.head}")
       case e => e.colour = localLevel(e)
     }
   }
 
-  override def determineAccess(element: ModelElement, myClassLike: ElementId, incomingReferences: Iterable[Refers]): PrivatiserLevel = {
+  override def determineAccess(element: ModelElement, myClassLike: ElementId, incomingReferences: Iterable[Refers]): Colour = {
     val myId = element.modelElementId
 
     var refFromContainer: ModelElement = null
@@ -51,13 +51,13 @@ class SimplePrivatiser(options: SimplePrivatiserCommandLine, model: ProjectModel
         refFromOutside = from
     }
     if (refFromOutside ne null)
-      NoChange(s"Its accessed by $refFromOutside")
+      dontChange(s"Its accessed by $refFromOutside")
     else if (refFromCompanion ne null)
-      Scoped.Private(myClassLike, s"Its private (assessed by companion - $refFromCompanion)")
+      makeChange(Scoped.Private(myClassLike, s"Its private (assessed by companion - $refFromCompanion)"))
     else if (refFromContainer ne null)
-      Scoped.Private(myClassLike, s"Its private (assessed by enclosing - $refFromContainer)")
+      makeChange(Scoped.Private(myClassLike, s"Its private (assessed by enclosing - $refFromContainer)"))
     else
-      Scoped.Private(myClassLike.dotThis, s"Its private (seems unused)")
+      makeChange(Scoped.Private(myClassLike.dotThis, s"Its private (seems unused)"))
   }
 
 }


### PR DESCRIPTION
Provide a structure for Mark, to enable reuse of "ban because"
Simplify merging of colours
Reuse common colours
Make some colour assignment more readable

A few minor cleanups