### PR TITLE
Misc running ScalaClean fixes

### DIFF
--- a/command/src/main/scala/scalaclean/rules/RuleRun.scala
+++ b/command/src/main/scala/scalaclean/rules/RuleRun.scala
@@ -22,14 +22,7 @@ abstract class AbstractRule[T <: ScalaCleanCommandLine] {
   def main(args: Array[String]): Unit = {
     val options = cmdLine
     parse(options, args)
-
-    val projectProps = options.files.map(f => Paths.get(f.toString))
-
-    val projectSet = new ProjectSet(projectProps: _*)
-
-    println(s"Running rule: ${getClass.getSimpleName}")
-    apply(options, projectSet).run()
-
+    apply(options, new ProjectSet(options.files: _*)).run()
   }
 
   def parse(cmdLine: ScalaCleanCommandLine, args: Array[String]): Unit = {
@@ -44,8 +37,7 @@ abstract class AbstractRule[T <: ScalaCleanCommandLine] {
         System.err.println(s"java ${getClass.getName} [options...] arguments...")
         parser.printUsage(System.err)
         System.err.println()
-        System.exit(1)
-        ???
+        sys.exit(1)
     }
   }
 
@@ -260,11 +252,10 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
   }
 
   def run(): Boolean = {
-
-    val projectProps = options.files.map(f => Paths.get(f.toString))
-
-    val projectSet = new ProjectSet(projectProps: _*)
-
+    val projectSet = model match {
+      case projectSet: ProjectSet => projectSet
+      case _                      => new ProjectSet(options.files: _*)
+    }
     println(s"Running rule: $name")
 
     beforeStart()

--- a/readme.md
+++ b/readme.md
@@ -39,7 +39,7 @@ This will create a jar for the compiler plugin.
 
 You will need to find the full path for the file e.g. 
 
-```/workspace/ScalaClean/analysisPlugin/target/scala-2.12/analysisPlugin_2.12.10-0.1.0-SNAPSHOT-assembly.jar```
+```/workspace/ScalaClean/analysisPlugin/target/scala-2.12/analysisPlugin_2.12.12-0.1.0-SNAPSHOT-assembly.jar```
 
 ### 3. Update your build to pull in semanticDB and the ScalaClean plugin.
 
@@ -51,7 +51,7 @@ settings(
     val srcLocations = (sourceDirectories in Compile).value.mkString(java.io.File.pathSeparator)
     Seq(
       "-Yrangepos", 
-      "-Xplugin:/workspace/ScalaClean/analysisPlugin/target/scala-2.12/analysisPlugin_2.12.10-0.1.0-SNAPSHOT-assembly.jar",
+      "-Xplugin:/workspace/ScalaClean/analysisPlugin/target/scala-2.12/analysisPlugin_2.12.12-0.1.0-SNAPSHOT-assembly.jar",
       s"-P:scalaclean-analysis-plugin:srcdirs:$srcLocations"
     )
   }
@@ -79,7 +79,9 @@ Creates: ```/workspace/ScalaClean/command/target/scala-2.12/command-assembly-0.1
 
 Now you can run ScalaClean using this jar.  Point ScalaClean at your projects ```ScalaClean.properties``` files e.g.:
 
-```java -jar $SCALACLEAN_JAR deadcode `find myproject -name "ScalaClean.properties"```
+```bash
+java -cp $SCALACLEAN_JAR scalaclean.rules.deadcode.FullDeadCodeRemover --filesRoot ./akka-actor/target/classes/META-INF
+```
 
 By default it will print out the diff that it computes.  To apply the changes directly add ```--replace``` to the command
 before the list of files.  *BEWARE* - This is destructive - do not run it on code you care about that you


### PR DESCRIPTION
* Fix README instructions: using 2.12.12 and the new CLI UX
* Give ScalaCleanCommandLine non-null default values, otherwise arg4j
  will throw a NPE while trying to give usage info (or something)
* Reuse the existing ProjectSet, if possible, rather than re-instantiate
  and re-println a bunch of details