### PR TITLE
command line parsing

### DIFF
--- a/tests/src/main/scala/scalaclean/cli/AbstractProjectTestRunner.scala
+++ b/tests/src/main/scala/scalaclean/cli/AbstractProjectTestRunner.scala
@@ -47,8 +47,7 @@ abstract class AbstractProjectTestRunner[Cmd <: ScalaCleanCommandLine: ClassTag,
     options._rulePlugins = runOptions.rulePluginText.asJava
     options.testOptions.validate = true
     options.testOptions.expectationSuffix = expectationSuffix
-    import scala.collection.JavaConverters._
-    options._paths = propsFiles.asJava
+    options._paths = Some(propsFiles)
 
     customise(options)
 


### PR DESCRIPTION
create options for the optional args
`Path.get("<none>")` fails on windows