### PR TITLE
source consistency

### DIFF
--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/AnalysisModel.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/AnalysisModel.scala
@@ -401,5 +401,13 @@ case class ModelClass(tree: Global#ClassDef, common: ModelCommon, isAbstract: Bo
     extends ModelSymbol
     with ClassLike
 
-case class ModelTrait(tree: Global#ClassDef, common: ModelCommon)                extends ModelSymbol with ClassLike
-case class ModelSource(tree: Global#Tree, common: ModelCommon, encoding: String) extends ModelSymbol
+case class ModelTrait(tree: Global#ClassDef, common: ModelCommon) extends ModelSymbol with ClassLike
+
+case class ModelSource(
+    tree: Global#Tree,
+    common: ModelCommon,
+    encoding: String,
+    length: Int,
+    javaHash: Int,
+    murmurHash: Int
+) extends ModelSymbol

--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ElementsWriter.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ElementsWriter.scala
@@ -35,7 +35,7 @@ class ElementsWriter(file: File) extends CommonWriter(file) {
       case x: ModelFields => commonPrefix(x) ::: List(x.syntheticName, x.isLazy, x.fieldCount)
       case x: ModelVal    => commonPrefix(x) ::: fieldCommon(x) ::: List(x.isLazy)
       case x: ModelVar    => commonPrefix(x) ::: fieldCommon(x)
-      case x: ModelSource => commonPrefix(x) ::: List(x.encoding)
+      case x: ModelSource => commonPrefix(x) ::: List(x.encoding, x.length, x.javaHash, x.murmurHash)
     }
     val msg = fields.mkString(",")
 

--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ModelSymbolBuilder.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ModelSymbolBuilder.scala
@@ -1,12 +1,14 @@
 package org.scalaclean.analysis
 
 import java.nio.file.{Path, Paths}
+import java.util
 
 import scalaclean.model.{ElementIdManager, FieldPath}
 
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.reflect.internal.util.NoPosition
+import scala.reflect.io.AbstractFile
 import scala.tools.nsc.Global
 
 trait ModelSymbolBuilder {
@@ -18,6 +20,7 @@ trait ModelSymbolBuilder {
 
   private val mSymbolCache2 = mutable.Map[global.Symbol, ModelCommon]()
   private val mSymbolCache  = mutable.Map[global.Symbol, ModelCommon]()
+  private val fileToSafePath  = new util.IdentityHashMap[AbstractFile, Path]()
 //  private val aliases  = mutable.Map[global.Symbol, ModelCommon]()
 
   def externalSymbol(gSym: Global#Symbol): ModelCommon = {
@@ -82,7 +85,7 @@ trait ModelSymbolBuilder {
           if (gSym.pos == NoPosition) (-1, -1, -1) else (gSym.pos.start, gSym.pos.end, gSym.pos.focus.start)
         val sourceFile =
           if (gSym.sourceFile != null)
-            gSym.sourceFile.file.toPath.toAbsolutePath.toRealPath()
+            fileToSafePath.computeIfAbsent(gSym.sourceFile, _.file.toPath.toAbsolutePath.toRealPath())
           else
             Paths.get("-")
 

--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCleanCompilerPlugin.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCleanCompilerPlugin.scala
@@ -30,6 +30,8 @@ class ScalaCleanCompilerPlugin(override val global: Global) extends Plugin {
     for (option <- realOptions) {
       if (option == "debug:true") {
         component.debug = true
+      } else if (option == "copySources:true") {
+        component.copySources = true
       } else if (option.startsWith("extension:")) {
         val end = {
           val end = option.indexOf(':', 10)

--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCompilerPluginComponent.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/ScalaCompilerPluginComponent.scala
@@ -131,7 +131,7 @@ class ScalaCompilerPluginComponent(val global: Global) extends PluginComponent w
 
     override def apply(unit: global.CompilationUnit): Unit = {
 
-      val sourceFile = unit.source.file.file.toPath.toAbsolutePath.toRealPath()
+      val sourceFile = sanePath(unit.source.file)
 
       files += sourceFile
 
@@ -233,7 +233,7 @@ class ScalaCompilerPluginComponent(val global: Global) extends PluginComponent w
     val logTransScope = true
 
     def traverseSource(unit: CompilationUnit): Unit = {
-      val sourceFile = unit.source.file.file.toPath.toAbsolutePath.toRealPath()
+      val sourceFile = sanePath(unit.source.file)
       val content = new String(unit.source.content)
       val sourceSymbol = {
         ModelSource(

--- a/analysisPlugin/src/main/scala/org/scalaclean/analysis/SourceCopier.scala
+++ b/analysisPlugin/src/main/scala/org/scalaclean/analysis/SourceCopier.scala
@@ -1,0 +1,57 @@
+package org.scalaclean.analysis
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{ Files, Path }
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+
+trait SourceCopier extends AutoCloseable {
+  def copySource(sourceSymbol: ModelSource, content: String): Unit
+}
+
+object NoSourceCopier extends SourceCopier {
+  override def copySource(sourceSymbol: ModelSource, content: String): Unit = ()
+
+  override def close(): Unit = ()
+}
+
+class JarSourceCopier(jarPath: Path) extends SourceCopier {
+
+  var _jarWriter: JarOutputStream = null
+
+  private def jarWriter: JarOutputStream = {
+    if (_jarWriter == null) {
+      _jarWriter = new JarOutputStream(Files.newOutputStream(jarPath))
+      _jarWriter.setLevel(9)
+      _jarWriter.setMethod(ZipEntry.DEFLATED)
+    }
+    _jarWriter
+  }
+
+  override def copySource(sourceSymbol: ModelSource, content: String): Unit = {
+    try {
+      val path = sourceSymbol.common.sourceFile
+      assert(path.isAbsolute, path.toString)
+      val name = path.getRoot.relativize(path).toString
+      val ze = new ZipEntry(name)
+      val jar = jarWriter
+      val bytes = content.getBytes(StandardCharsets.UTF_8)
+      ze.setSize(bytes.length)
+      jar.putNextEntry(ze)
+      jar.write(bytes)
+      jar.closeEntry()
+    } catch {
+      case e: Exception =>
+        e.printStackTrace()
+        e.printStackTrace()
+        e.printStackTrace()
+        e.printStackTrace()
+    }
+
+  }
+
+  override def close(): Unit = if (_jarWriter ne null) {
+    _jarWriter.close()
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -104,6 +104,7 @@ lazy val unitTestProject = project
         s"-Jdummy=${jar.lastModified}", // ensures recompile
 //        "-P:scalaclean-analysis-plugin:debug:true",
         s"-P:scalaclean-analysis-plugin:srcdirs:$srcLocations",
+        "-P:scalaclean-analysis-plugin:copySources:true"
       )
     }
   )

--- a/command/src/main/scala/scalaclean/cli/SourceValidation.java
+++ b/command/src/main/scala/scalaclean/cli/SourceValidation.java
@@ -1,0 +1,17 @@
+package scalaclean.cli;
+
+public enum SourceValidation {
+    /**
+     * No validation
+     */
+    NONE,
+    /**
+     * Skip the file if it doesn't match
+     */
+    SKIP,
+    /**
+     * Mark the file as a failed to run rules
+     */
+    FAIL
+
+}

--- a/command/src/main/scala/scalaclean/model/impl/ProjectImpl.scala
+++ b/command/src/main/scala/scalaclean/model/impl/ProjectImpl.scala
@@ -1,19 +1,22 @@
 package scalaclean.model.impl
 
 import java.io.File
-import java.net.{ URL, URLClassLoader }
-import java.nio.file.{ Files, Path, Paths }
+import java.net.{URL, URLClassLoader}
+import java.nio.file.{Files, Path, Paths}
 import java.util.Properties
 import java.util.concurrent.ConcurrentHashMap
+import java.util.jar.JarFile
 
-import scala.meta.internal.symtab.{ GlobalSymbolTable, SymbolTable }
-import scala.meta.io.{ AbsolutePath, Classpath }
+import scalaclean.model.{AllProjectsModel, SingleProjectModel, SourceModel}
 
-object Project {
+import scala.meta.internal.symtab.{GlobalSymbolTable, SymbolTable}
+import scala.meta.io.{AbsolutePath, Classpath}
+
+object ProjectImpl {
 
   import org.scalaclean.analysis.PropertyNames._
 
-  def apply(propsPath: Path, projects: ProjectSet): Project = this.synchronized {
+  def apply(propsPath: Path, projects: ProjectSet): ProjectImpl = this.synchronized {
     val props = new Properties()
     println("PropsPath = " + propsPath)
     props.load(Files.newBufferedReader(propsPath))
@@ -27,6 +30,7 @@ object Project {
     val elementsFilePath      = props.getProperty(prop_elementsFile).replace(sourceDirSep, File.separator)
     val relationshipsFilePath = props.getProperty(prop_relationshipsFile).replace(sourceDirSep, File.separator)
     val extensionsFilePath    = props.getProperty(prop_extensionsFile).replace(sourceDirSep, File.separator)
+    val srcJarPath            = propsPath.resolveSibling("sources.jar")
     val srcBuildBase          = props.getProperty(prop_srcBuildBase).replace(sourceDirSep, File.separator)
     val srcFiles =
       props.getProperty(prop_srcFiles, "").replace(sourceDirSep, File.separator).split(File.pathSeparatorChar).toSet
@@ -43,7 +47,7 @@ object Project {
 
     val classPath = Classpath(classpathValue)
 
-    new Project(
+    new ProjectImpl(
       projects,
       classPath,
       outputPath,
@@ -52,6 +56,7 @@ object Project {
       elementsFilePath,
       relationshipsFilePath,
       extensionsFilePath,
+      srcJarPath,
       srcFiles,
       sourceDirSep
     )
@@ -59,7 +64,7 @@ object Project {
 
 }
 
-class Project private (
+class ProjectImpl private(
     val projects: ProjectSet,
     val classPath: Classpath,
     val outputPath: String,
@@ -68,9 +73,10 @@ class Project private (
     elementsFilePath: String,
     relationshipsFilePath: String,
     extensionsFilePath: String,
+    sourcesFilePath: Path,
     val srcFiles: Set[String],
     sourceDirSep: String
-) {
+) extends SingleProjectModel {
   def symbolTable: SymbolTable = GlobalSymbolTable(classPath, includeJdk = true)
 
   lazy val classloader: ClassLoader = new URLClassLoader(Array(new URL("file:" + outputPath + "/")), null)
@@ -84,4 +90,28 @@ class Project private (
     sourcesMap.computeIfAbsent(name, p => SourceData(this, Paths.get(p)))
   }
 
+  lazy val sourcesJar = {
+    val path = sourcesFilePath
+    if (Files.exists(path)) {
+      Some(new JarFile(path.toFile, false))
+    } else None
+  }
+  override def originalSource(file: SourceModel): Option[String] = {
+    sourcesJar map { jar =>
+      assert(file.filename.isAbsolute, file.filename.toString)
+      val name = file.filename.getRoot.relativize(file.filename.toRealPath()).toString
+      val entry = jar.getEntry(name)
+      val data = new Array[Byte](entry.getSize.toInt)
+      val is = jar.getInputStream(entry)
+      var offset = 0
+      while (data.length - offset > 0) {
+        val read = is.read(data, offset, data.length - offset)
+        assert (read > 0)
+        offset += read
+      }
+      new String(data, file.encoding)
+    }
+  }
+
+  override def allProjects: AllProjectsModel = projects
 }

--- a/command/src/main/scala/scalaclean/model/impl/ProjectSet.scala
+++ b/command/src/main/scala/scalaclean/model/impl/ProjectSet.scala
@@ -7,8 +7,8 @@ import scalaclean.model._
 import scala.collection.immutable
 import scala.reflect.ClassTag
 
-class ProjectSet(projectPropertyPaths: Path*) extends ProjectModel {
-  val projects: List[Project] = projectPropertyPaths.toList.map(p => Project(p, this))
+class ProjectSet(projectPropertyPaths: Path*) extends AllProjectsModel {
+  override val projects: List[ProjectImpl] = projectPropertyPaths.toList.map(p => ProjectImpl(p, this))
 
   val elements: Map[ElementId, ElementModelImpl] = {
     val (elements, rels: immutable.Seq[BasicRelationshipInfo]) = projects.map(_.read).unzip

--- a/command/src/main/scala/scalaclean/model/impl/SourceData.scala
+++ b/command/src/main/scala/scalaclean/model/impl/SourceData.scala
@@ -8,4 +8,4 @@ import java.nio.file.Path
  * @param project the containing project
  * @param path    the relative path to the source from the project path
  */
-case class SourceData(project: Project, path: Path) {}
+case class SourceData(project: ProjectImpl, path: Path) {}

--- a/command/src/main/scala/scalaclean/rules/RuleRun.scala
+++ b/command/src/main/scala/scalaclean/rules/RuleRun.scala
@@ -300,8 +300,8 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
 
   }
 
-  def writeToFile(path: Path, content: String): Unit = {
-    Files.write(path, content.getBytes)
+  def writeToFile(path: Path, content: String, encoding: String): Unit = {
+    Files.write(path, content.getBytes(Charset.forName(encoding)))
   }
 
   def validateSource(sourceFile: SourceFile): Boolean = {
@@ -380,7 +380,7 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
                 changed |= testSupport.compareAgainstFile(debug, expectedFile, expectedContent, obtained)
                 if (options.replace) {
                   // overwrite the '.expected' file
-                  writeToFile(expectedFile, obtained)
+                  writeToFile(expectedFile, obtained, sourceFile.file.encoding)
                 }
               } else {
                 if (options.replace) {
@@ -392,7 +392,7 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
                         patchStats.appliedFixes(sourceFile, fixes)
                         if (debug)
                           println(s"DEBUG: Overwriting existing file: ${file.filename} with ${fixes.patches.size} changes")
-                        writeToFile(file.filename, obtained)
+                        writeToFile(file.filename, obtained, sourceFile.file.encoding)
                     }
                   }
 

--- a/command/src/main/scala/scalaclean/rules/RuleRun.scala
+++ b/command/src/main/scala/scalaclean/rules/RuleRun.scala
@@ -306,7 +306,7 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
 
   def validateSource(sourceFile: SourceFile): Boolean = {
     def isChanged(): String = {
-      var changed = new StringBuilder
+      val changed = new StringBuilder
       val content = sourceFile.content
       if (content.length != sourceFile.file.sourceLength)
         changed append s"Source validation failed for ${sourceFile.file.filename} : length found ${content.length} expected ${sourceFile.file.sourceLength}\n"

--- a/command/src/main/scala/scalaclean/rules/RuleRun.scala
+++ b/command/src/main/scala/scalaclean/rules/RuleRun.scala
@@ -6,16 +6,18 @@ import java.nio.file.{Files, Path, Paths}
 
 import scalaclean.cli.{SCPatchUtil, ScalaCleanCommandLine}
 import scalaclean.model._
-import scalaclean.model.impl.{Project, ProjectSet}
+import scalaclean.model.impl.{ProjectImpl, ProjectSet}
 import scalaclean.util.{DiffAssertions, PatchStats, SingleFileVisit}
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
+import scala.util.hashing.MurmurHash3
 import scala.util.{Failure, Success, Try}
 
 abstract class AbstractRule[T <: ScalaCleanCommandLine] {
   type Rule <: RuleRun[T]
   def cmdLine: T
-  def apply(options: T, model: ProjectModel): Rule
+  def apply(options: T, model: AllProjectsModel): Rule
 
   def main(args: Array[String]): Unit = {
     val options = cmdLine
@@ -43,17 +45,23 @@ abstract class AbstractRule[T <: ScalaCleanCommandLine] {
 
 abstract class RuleRun[T <: ScalaCleanCommandLine] {
   val options: T
-  val model: ProjectModel
+  val model: AllProjectsModel
+
   def name = getClass.getSimpleName
 
-  private lazy val patchStats                 = new PatchStats(options)
-  def debug                                   = options.debug
-  def addComments                             = options.addComments
+  private lazy val patchStats = new PatchStats(options)
+
+  def debug = options.debug
+
+  def addComments = options.addComments
+
   def printSummary(projectName: String): Unit = patchStats.printSummary(projectName)
 
   type Colour = Mark[SpecificColour]
   type SpecificColour <: SomeSpecificColour
-  def dontChange(reason: String)        = Mark.dontChange[SpecificColour](SimpleReason(reason))
+
+  def dontChange(reason: String) = Mark.dontChange[SpecificColour](SimpleReason(reason))
+
   def makeChange(level: SpecificColour) = Mark.specific[SpecificColour](level)
 
   final def beforeStart(): Unit = {
@@ -105,7 +113,7 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
 
   def generateFixes(sourceFile: SourceFile): SingleFileVisit
 
-  def markAll[E <: ModelElement: ClassTag](colour: Colour): Unit = {
+  def markAll[E <: ModelElement : ClassTag](colour: Colour): Unit = {
     val all = model.allOf[E].toList
     model
       .allOf[E]
@@ -183,60 +191,60 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
 
   def allSerialisationEntries: Iterator[MethodModel] = {
     model.allOf[MethodModel].filter { method =>
-      (method.methodName == "writeObject" /*      && method.params == objectOutputStream */ ) ||
-      (method.methodName == "readObject" /*       && method.params == objectInputStream */ ) ||
-      (method.methodName == "readObjectNoData" /* && method.params == empty */ ) ||
-      (method.methodName == "writeReplace" /*     && method.params == empty */ ) ||
-      (method.methodName == "readResolve" /*      && method.params == empty */ )
+      (method.methodName == "writeObject" /*      && method.params == objectOutputStream */) ||
+        (method.methodName == "readObject" /*       && method.params == objectInputStream */) ||
+        (method.methodName == "readObjectNoData" /* && method.params == empty */) ||
+        (method.methodName == "writeReplace" /*     && method.params == empty */) ||
+        (method.methodName == "readResolve" /*      && method.params == empty */)
     }
     // ++
   }
 
-//  def generateHTML(generated: String, original: String): Unit = {
-//    import scala.io.Source
-//    val cssText: String = Source.fromResource("default-style.css").mkString
-//
-//    writeToFile(Paths.get("/tmp/code.css"), cssText)
-//    val sw = new StringWriter()
-//    val pw = new PrintWriter(sw)
-//    pw.println(
-//      """
-//        |<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-//        |<html xmlns="http://www.w3.org/1999/xhtml">
-//        |    <head>
-//        |        <title>XXXXX</title>
-//        |        <link rel="stylesheet" type="text/css" href="code.css" title="Style">
-//        |    </head>
-//        |    <body onload="initializeLinked()">
-//        |        <pre>
-//        |""".stripMargin
-//    )
-//
-//    pw.println(generated)
-//    pw.println("--------------------")
-//    pw.println("--------------------")
-//    pw.println(original)
-//    pw.println("--------------------")
-//
-//    pw.println(
-//      """        </pre>
-//        |    </body>
-//        |</html>
-//        |""".stripMargin
-//    )
-//
-//    pw.flush()
-//    val str = sw.toString
-//    writeToFile(Paths.get("/tmp/code.html"), str)
-//    //    Runtime.getRuntime.exec("open /tmp/code.html")
-//    //    System.exit(1)
-//
-//  }
+  //  def generateHTML(generated: String, original: String): Unit = {
+  //    import scala.io.Source
+  //    val cssText: String = Source.fromResource("default-style.css").mkString
+  //
+  //    writeToFile(Paths.get("/tmp/code.css"), cssText)
+  //    val sw = new StringWriter()
+  //    val pw = new PrintWriter(sw)
+  //    pw.println(
+  //      """
+  //        |<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+  //        |<html xmlns="http://www.w3.org/1999/xhtml">
+  //        |    <head>
+  //        |        <title>XXXXX</title>
+  //        |        <link rel="stylesheet" type="text/css" href="code.css" title="Style">
+  //        |    </head>
+  //        |    <body onload="initializeLinked()">
+  //        |        <pre>
+  //        |""".stripMargin
+  //    )
+  //
+  //    pw.println(generated)
+  //    pw.println("--------------------")
+  //    pw.println("--------------------")
+  //    pw.println(original)
+  //    pw.println("--------------------")
+  //
+  //    pw.println(
+  //      """        </pre>
+  //        |    </body>
+  //        |</html>
+  //        |""".stripMargin
+  //    )
+  //
+  //    pw.flush()
+  //    val str = sw.toString
+  //    writeToFile(Paths.get("/tmp/code.html"), str)
+  //    //    Runtime.getRuntime.exec("open /tmp/code.html")
+  //    //    System.exit(1)
+  //
+  //  }
 
   def run(): Boolean = {
     val projectSet = model match {
       case projectSet: ProjectSet => projectSet
-      case _                      => new ProjectSet(options.files: _*)
+      case _ => new ProjectSet(options.files: _*)
     }
     println(s"Running rule: $name")
 
@@ -260,22 +268,34 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
       src.filename.resolveSibling(src.filename.getFileName + options.testOptions.expectationSuffix + ".expected")
     }
 
-    def compareAgainstFile(debug: Boolean, expectedFile: Path, expected: String, obtained: String): Boolean = {
+    def diffString(diff: String, expectedFile: Path, p1: (String, String, Boolean), p2: (String, String, Boolean)) : String = {
+      val sb = new StringBuilder()
+      val (p1Value, p1Name, p1Show) = p1
+      val (p2Value, p2Name, p2Show) = p2
+      if (p1Show) {
+        sb.append(s"###########> $p1Name       <###########\n")
+        println(p1Value)
+      }
+      if (p2Show) {
+        sb.append(s"###########> $p2Name       <###########\n")
+        println(p2Value)
+      }
+      sb.append("###########> Diff       <###########\n")
+      sb.append(error2message(diff))
 
-      if (debug)
-        println("DEBUG Comparing obtained vs " + expectedFile)
+      sb.toString()
+    }
+    def compareAgainstFile(debug: Boolean, expectedFile: Path, expected: String, obtained: String): Boolean = {
 
       val diff = DiffAssertions.compareContents(obtained, expected)
       if (diff.nonEmpty) {
-        println("###########> obtained       <###########")
-        println(obtained)
-        println("###########> expected       <###########")
-        println(expected)
-        println("###########> Diff       <###########")
-        println(error2message(obtained, expected))
+        println(diffString(diff, expectedFile,(obtained, "obtained", true), (expected, "expected", true)))
         true
-      } else
+      } else {
+        if (debug)
+          println("DEBUG Comparing obtained vs " + expectedFile)
         false
+      }
     }
 
   }
@@ -284,13 +304,50 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
     Files.write(path, content.getBytes)
   }
 
+  def validateSource(sourceFile: SourceFile): Boolean = {
+    def isChanged(): String = {
+      var changed = new StringBuilder
+      val content = sourceFile.content
+      if (content.length != sourceFile.file.sourceLength)
+        changed append s"Source validation failed for ${sourceFile.file.filename} : length found ${content.length} expected ${sourceFile.file.sourceLength}\n"
+      if (content.hashCode != sourceFile.file.sourceJavaHash)
+        changed append s"Source validation failed for ${sourceFile.file.filename} : hash found ${content.hashCode} expected ${sourceFile.file.sourceJavaHash}"
+      if (MurmurHash3.stringHash(content) != sourceFile.file.sourceMurmurHash) {
+        changed append s"Source validation failed for ${sourceFile.file.filename} : MurmurHash3 found ${MurmurHash3.stringHash(content)} expected ${sourceFile.file.sourceMurmurHash}"
+      }
+      if (changed.nonEmpty) {
+        sourceFile.file.project.originalSource(sourceFile.file) foreach {
+          original =>
+            changed append "\n"
+            val diff = DiffAssertions.compareContents(content, original)
+            changed append testSupport.diffString(diff, sourceFile.file.filename, (original, "compiled", true), (content, "current", true))
+        }
+
+      }
+      changed.toString()
+    }
+
+    import scalaclean.cli.SourceValidation
+    options.sourceValidation match {
+      case SourceValidation.NONE => true
+      case SourceValidation.SKIP =>
+        val changed = isChanged()
+        if (!changed.isEmpty) patchStats.sourceChanged(sourceFile, changed, false)
+        changed.isEmpty
+      case SourceValidation.FAIL =>
+        val changed = isChanged()
+        if (!changed.isEmpty) patchStats.sourceChanged(sourceFile, changed, true)
+        changed.isEmpty
+    }
+  }
+
   /**
-   * @param project The target project
-   * @return True if diffs were seen or files were changed
-   */
+    * @param project The target project
+    * @return True if diffs were seen or files were changed
+    */
   def runRuleOnProject(
-      project: Project
-  ): Boolean = {
+                        project: ProjectImpl
+                      ): Boolean = {
 
     var changed = false
 
@@ -307,7 +364,7 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
           patchStats.fileNotFound(sourceFile)
           if (!options.skipNonexistentFiles)
             throw new IllegalStateException(s"cant find file $file")
-        } else {
+        } else if (validateSource(sourceFile))
 
           Try(generateFixes(sourceFile)) match {
             case Failure(t) => patchStats.failedToGenerateFixes(sourceFile, t)
@@ -346,7 +403,6 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
                 }
               }
           }
-        }
       }
     }
     changed

--- a/command/src/main/scala/scalaclean/rules/RuleRun.scala
+++ b/command/src/main/scala/scalaclean/rules/RuleRun.scala
@@ -274,11 +274,11 @@ abstract class RuleRun[T <: ScalaCleanCommandLine] {
       val (p2Value, p2Name, p2Show) = p2
       if (p1Show) {
         sb.append(s"###########> $p1Name       <###########\n")
-        println(p1Value)
+        sb.append(p1Value)
       }
       if (p2Show) {
         sb.append(s"###########> $p2Name       <###########\n")
-        println(p2Value)
+        sb.append(p2Value)
       }
       sb.append("###########> Diff       <###########\n")
       sb.append(error2message(diff))

--- a/command/src/main/scala/scalaclean/rules/deadcode/AbstractDeadCodeRemover.scala
+++ b/command/src/main/scala/scalaclean/rules/deadcode/AbstractDeadCodeRemover.scala
@@ -174,9 +174,7 @@ abstract class AbstractDeadCodeRemover[T <: AbstractDeadCodeCommandLine] extends
 
   override def generateFixes(sourceFile: SourceFile): SingleFileVisit = {
 
-    object visitor extends ScalaCleanTreePatcher(sourceFile) {
-      override def debug: Boolean       = options.debug
-      override def addComments: Boolean = options.addComments
+    object visitor extends ScalaCleanTreePatcher(sourceFile, AbstractDeadCodeRemover.this.options) {
 
       override protected def visitInSource(element: ModelElement): Boolean = {
         element match {

--- a/command/src/main/scala/scalaclean/rules/deadcode/FullDeadCodeRemover.scala
+++ b/command/src/main/scala/scalaclean/rules/deadcode/FullDeadCodeRemover.scala
@@ -1,6 +1,6 @@
 package scalaclean.rules.deadcode
 
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.rules.AbstractRule
 
 object FullDeadCodeRemover extends AbstractRule[FullDeadCodeCommandLine] {
@@ -8,10 +8,10 @@ object FullDeadCodeRemover extends AbstractRule[FullDeadCodeCommandLine] {
   override type Rule = FullDeadCodeRemover
 
   override def cmdLine                                                      = new FullDeadCodeCommandLine
-  override def apply(options: FullDeadCodeCommandLine, model: ProjectModel) = new Rule(options, model)
+  override def apply(options: FullDeadCodeCommandLine, model: AllProjectsModel) = new Rule(options, model)
 }
 
-class FullDeadCodeRemover(override val options: FullDeadCodeCommandLine, override val model: ProjectModel)
+class FullDeadCodeRemover(override val options: FullDeadCodeCommandLine, override val model: AllProjectsModel)
     extends AbstractDeadCodeRemover[FullDeadCodeCommandLine]
 
 class FullDeadCodeCommandLine extends AbstractDeadCodeCommandLine

--- a/command/src/main/scala/scalaclean/rules/deadcode/SimpleDeadCodeRemover.scala
+++ b/command/src/main/scala/scalaclean/rules/deadcode/SimpleDeadCodeRemover.scala
@@ -9,11 +9,11 @@ object SimpleDeadCodeRemover extends AbstractRule[SimpleDeadCodeCommandLine] {
   override type Rule = SimpleDeadCodeRemover
 
   override def cmdLine                                                        = new SimpleDeadCodeCommandLine
-  override def apply(options: SimpleDeadCodeCommandLine, model: ProjectModel) = new Rule(options, model)
+  override def apply(options: SimpleDeadCodeCommandLine, model: AllProjectsModel) = new Rule(options, model)
 
 }
 
-class SimpleDeadCodeRemover(override val options: SimpleDeadCodeCommandLine, override val model: ProjectModel)
+class SimpleDeadCodeRemover(override val options: SimpleDeadCodeCommandLine, override val model: AllProjectsModel)
     extends AbstractDeadCodeRemover[SimpleDeadCodeCommandLine] {
 
   //TODO plugin for tweaks

--- a/command/src/main/scala/scalaclean/rules/finaliser/Finaliser.scala
+++ b/command/src/main/scala/scalaclean/rules/finaliser/Finaliser.scala
@@ -14,10 +14,10 @@ object Finaliser extends AbstractRule[FinaliserCommandLine] {
   override type Rule = Finaliser
 
   override def cmdLine                                                   = new FinaliserCommandLine
-  override def apply(options: FinaliserCommandLine, model: ProjectModel) = new Rule(options, model)
+  override def apply(options: FinaliserCommandLine, model: AllProjectsModel) = new Rule(options, model)
 }
 
-class Finaliser(override val options: FinaliserCommandLine, override val model: ProjectModel)
+class Finaliser(override val options: FinaliserCommandLine, override val model: AllProjectsModel)
     extends RuleRun[FinaliserCommandLine] {
 
   type SpecificColour = FinaliserLevel
@@ -162,9 +162,7 @@ class Finaliser(override val options: FinaliserCommandLine, override val model: 
 
   override def generateFixes(sourceFile: SourceFile): SingleFileVisit = {
 
-    object visitor extends ScalaCleanTreePatcher(sourceFile) {
-      override def debug: Boolean       = options.debug
-      override def addComments: Boolean = options.addComments
+    object visitor extends ScalaCleanTreePatcher(sourceFile, Finaliser.this.options) {
 
       def handleDecl(modelElement: ModelElement): Unit = {
         modelElement.colour.specific match {

--- a/command/src/main/scala/scalaclean/rules/privatiser/AbstractPrivatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/AbstractPrivatiser.scala
@@ -7,7 +7,7 @@ import scalaclean.rules.{RuleRun, SourceFile}
 import scalaclean.util.{ScalaCleanTreePatcher, SingleFileVisit}
 import scala.meta.tokens.Token
 
-abstract class AbstractPrivatiser[T <: AbstractPrivatiserCommandLine](val options: T, val model: ProjectModel)
+abstract class AbstractPrivatiser[T <: AbstractPrivatiserCommandLine](val options: T, val model: AllProjectsModel)
     extends RuleRun[T] {
 
   type SpecificColour = PrivatiserLevel
@@ -167,7 +167,7 @@ abstract class AbstractPrivatiser[T <: AbstractPrivatiserCommandLine](val option
 
   override def generateFixes(sourceFile: SourceFile): SingleFileVisit = {
 
-    object visitor extends ScalaCleanTreePatcher(sourceFile) {
+    object visitor extends ScalaCleanTreePatcher(sourceFile, AbstractPrivatiser.this.options) {
 
       // TODO CURRENT UNUSED
       //      def existingAccess(mods: Seq[Mod]): (Option[Mod], PrivatiserLevel) = {
@@ -221,10 +221,6 @@ abstract class AbstractPrivatiser[T <: AbstractPrivatiserCommandLine](val option
       //
       //      }
       //
-
-      override def debug: Boolean = options.debug
-
-      override def addComments: Boolean = options.addComments
 
       override protected def visitInSource(modelElement: ModelElement): Boolean = {
         if (!modelElement.modelElementId.isLocal) {
@@ -303,14 +299,7 @@ abstract class AbstractPrivatiser[T <: AbstractPrivatiserCommandLine](val option
 
       visitor.visit(sourceFile.file)
 
-      val result = visitor.result
-      if (debug) {
-        println("--------NEW----------")
-        result.patches.foreach(println)
-        println("------------------")
-      }
-      result
-
+      visitor.result
   }
 
 }

--- a/command/src/main/scala/scalaclean/rules/privatiser/FullPrivatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/FullPrivatiser.scala
@@ -1,13 +1,13 @@
 package scalaclean.rules.privatiser
 
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.rules.AbstractRule
 
 object FullPrivatiser extends AbstractRule[FullPrivatiserCommandLine] {
   override type Rule = FullPrivatiser
   override def cmdLine                                                        = new FullPrivatiserCommandLine
-  override def apply(options: FullPrivatiserCommandLine, model: ProjectModel) = new Rule(options, model)
+  override def apply(options: FullPrivatiserCommandLine, model: AllProjectsModel) = new Rule(options, model)
 }
 
-class FullPrivatiser(options: FullPrivatiserCommandLine, model: ProjectModel) extends AbstractPrivatiser(options, model)
+class FullPrivatiser(options: FullPrivatiserCommandLine, model: AllProjectsModel) extends AbstractPrivatiser(options, model)
 class FullPrivatiserCommandLine                                               extends AbstractPrivatiserCommandLine

--- a/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
@@ -7,10 +7,10 @@ object SimplePrivatiser extends AbstractRule[SimplePrivatiserCommandLine] {
   override type Rule = SimplePrivatiser
 
   override def cmdLine                                                          = new SimplePrivatiserCommandLine
-  override def apply(options: SimplePrivatiserCommandLine, model: ProjectModel) = new Rule(options, model)
+  override def apply(options: SimplePrivatiserCommandLine, model: AllProjectsModel) = new Rule(options, model)
 }
 
-class SimplePrivatiser(options: SimplePrivatiserCommandLine, model: ProjectModel)
+class SimplePrivatiser(options: SimplePrivatiserCommandLine, model: AllProjectsModel)
     extends AbstractPrivatiser(options, model) {
 
 

--- a/command/src/main/scala/scalaclean/test/ShowColour.scala
+++ b/command/src/main/scala/scalaclean/test/ShowColour.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 /**
  * A rule use to test that plugin marks are set correctly
  */
-class ShowColour(theModel: ProjectModel, pluginParams: List[String]) extends TestCommon("ShowColour", theModel) {
+class ShowColour(theModel: AllProjectsModel, pluginParams: List[String]) extends TestCommon("ShowColour", theModel) {
   val cmdLine = new ScalaCleanCommandLine {}
   cmdLine._rulePlugins = pluginParams.asJava
   dummyRule.markInitial()
@@ -29,7 +29,7 @@ class ShowColour(theModel: ProjectModel, pluginParams: List[String]) extends Tes
 
   object dummyRule extends RuleRun[ScalaCleanCommandLine] {
     override val options: ScalaCleanCommandLine = cmdLine
-    override val model: ProjectModel = theModel
+    override val model: AllProjectsModel = theModel
     override type SpecificColour = ASpecificColour
 
     override def runRule(): Unit = ???

--- a/command/src/main/scala/scalaclean/test/TestBase.scala
+++ b/command/src/main/scala/scalaclean/test/TestBase.scala
@@ -2,15 +2,15 @@ package scalaclean.test
 
 import java.nio.file.Path
 
+import scalaclean.cli.ScalaCleanCommandLine
 import scalaclean.model._
 import scalaclean.rules.SourceFile
 import scalaclean.util._
 
 /**
- * A rule use to test the that incoming references ar set correctly,
- * needs to be run after ScalaCleanTestAnalysis
+ * unit test support
  */
-abstract class TestBase(val name: String, model: ProjectModel) {
+abstract class TestBase(val name: String, model: AllProjectsModel) {
 
   def beforeStart(): Unit = {
     println(s"Test Rule $name beforeStart START")
@@ -29,9 +29,7 @@ abstract class TestBase(val name: String, model: ProjectModel) {
         .allOf[SourceModel].map(_.filename).mkString("\n")}"))
     val sourceFile = new SourceFile(sModel)
 
-    object visitor extends ScalaCleanTreePatcher(sourceFile) {
-      override def debug: Boolean       = false
-      override def addComments: Boolean = false
+    object visitor extends ScalaCleanTreePatcher(sourceFile, new ScalaCleanCommandLine {}) {
 
       private def visit(modelElement: ModelElement): Boolean = {
         toPatch(elementInfo(modelElement), modelElement)

--- a/command/src/main/scala/scalaclean/test/TestCommon.scala
+++ b/command/src/main/scala/scalaclean/test/TestCommon.scala
@@ -2,7 +2,7 @@ package scalaclean.test
 
 import scalaclean.model._
 
-abstract class TestCommon(name: String, model: ProjectModel) extends TestBase(name, model) {
+abstract class TestCommon(name: String, model: AllProjectsModel) extends TestBase(name, model) {
 
   /**
    * Visit the model element.

--- a/command/src/main/scala/scalaclean/test/TestExtends.scala
+++ b/command/src/main/scala/scalaclean/test/TestExtends.scala
@@ -7,7 +7,7 @@ import scalaclean.model._
  * A rule use to test that extends API works correctly,
  * needs to be run after TestAnalysis
  */
-class Test_extends(directOnly: Boolean, filter: ExtendsClassLike, testNameSuffix: String, model: ProjectModel)
+class Test_extends(directOnly: Boolean, filter: ExtendsClassLike, testNameSuffix: String, model: AllProjectsModel)
     extends TestCommon(s"Test_extends$testNameSuffix", model) {
 
   override def visitInSource(modelElement: ModelElement): String = modelElement match {
@@ -27,7 +27,7 @@ class Test_extendsCompiled(
     directOnly: Boolean,
     filter: ExtendsClassLikeCompiled,
     testNameSuffix: String,
-    model: ProjectModel
+    model: AllProjectsModel
 ) extends TestCommon(s"Test_extendsCompiled$testNameSuffix", model) {
 
   override def visitInSource(modelElement: ModelElement): String = modelElement match {
@@ -43,7 +43,7 @@ class Test_extendsCompiled(
  * A rule use to test that extends API works correctly,
  * needs to be run after TestAnalysis
  */
-class Test_extendedBy(directOnly: Boolean, filter: ExtendedByClassLike, testNameSuffix: String, model: ProjectModel)
+class Test_extendedBy(directOnly: Boolean, filter: ExtendedByClassLike, testNameSuffix: String, model: AllProjectsModel)
     extends TestCommon(s"Test_extendedBy$testNameSuffix", model) {
 
   override def visitInSource(modelElement: ModelElement): String = modelElement match {

--- a/command/src/main/scala/scalaclean/test/TestExtensions.scala
+++ b/command/src/main/scala/scalaclean/test/TestExtensions.scala
@@ -6,7 +6,7 @@ import scalaclean.model._
  * A rule use to test that annotations are st correctly,
  * needs to be run after TestAnalysis
  */
-class TestExtensions(model: ProjectModel) extends TestCommon("TestExtensions", model) {
+class TestExtensions(model: AllProjectsModel) extends TestCommon("TestExtensions", model) {
 
   override def visitInSource(modelElement: ModelElement): String = {
     modelElement.annotations match {

--- a/command/src/main/scala/scalaclean/test/TestInherits.scala
+++ b/command/src/main/scala/scalaclean/test/TestInherits.scala
@@ -3,7 +3,7 @@ package scalaclean.test
 import scalaclean.model._
 
 /** A rule use to test the that overrides as set correctly */
-class Test_internalDirectOverrides(model: ProjectModel) extends TestCommon("Test_internalDirectOverrides", model) {
+class Test_internalDirectOverrides(model: AllProjectsModel) extends TestCommon("Test_internalDirectOverrides", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
     elementsInTestFormat("internalDirectOverrides", modelElement,
@@ -12,7 +12,7 @@ class Test_internalDirectOverrides(model: ProjectModel) extends TestCommon("Test
 }
 
 /** A rule use to test the that overrides as set correctly */
-class Test_internalTransitiveOverrides(model: ProjectModel)
+class Test_internalTransitiveOverrides(model: AllProjectsModel)
     extends TestCommon("Test_internalTransitiveOverrides", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
@@ -21,7 +21,7 @@ class Test_internalTransitiveOverrides(model: ProjectModel)
 }
 
 /** A rule use to test the that overrides as set correctly */
-class Test_allDirectOverrides(model: ProjectModel) extends TestCommon("Test_allDirectOverrides", model) {
+class Test_allDirectOverrides(model: AllProjectsModel) extends TestCommon("Test_allDirectOverrides", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
     elementAndIdsInTestFormat("allDirectOverrides", modelElement,
@@ -29,7 +29,7 @@ class Test_allDirectOverrides(model: ProjectModel) extends TestCommon("Test_allD
 }
 
 /** A rule use to test the that overrides as set correctly */
-class Test_allTransitiveOverrides(model: ProjectModel) extends TestCommon("Test_allTransitiveOverrides", model) {
+class Test_allTransitiveOverrides(model: AllProjectsModel) extends TestCommon("Test_allTransitiveOverrides", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
     elementAndIdsInTestFormat("allTransitiveOverrides", modelElement,
@@ -37,7 +37,7 @@ class Test_allTransitiveOverrides(model: ProjectModel) extends TestCommon("Test_
 }
 
 /** A rule use to test the that overrides as set correctly */
-class Test_internalDirectOverriddenBy(model: ProjectModel)
+class Test_internalDirectOverriddenBy(model: AllProjectsModel)
     extends TestCommon("Test_internalDirectOverriddenBy", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
@@ -47,7 +47,7 @@ class Test_internalDirectOverriddenBy(model: ProjectModel)
 }
 
 /** A rule use to test the that overrides as set correctly */
-class Test_internalTransitiveOverriddenBy(model: ProjectModel)
+class Test_internalTransitiveOverriddenBy(model: AllProjectsModel)
     extends TestCommon("Test_internalTransitiveOverriddenBy", model) {
 
   override def visitInSource(modelElement: ModelElement): String =

--- a/command/src/main/scala/scalaclean/test/TestNodes.scala
+++ b/command/src/main/scala/scalaclean/test/TestNodes.scala
@@ -3,7 +3,7 @@ package scalaclean.test
 import scalaclean.model._
 
 /** Basic node types test */
-class TestNodes(model: ProjectModel) extends TestCommon("TestNodes", model) {
+class TestNodes(model: AllProjectsModel) extends TestCommon("TestNodes", model) {
 
   override def visitInSource(modelElement: ModelElement): String = {
     modelElement.toString

--- a/command/src/main/scala/scalaclean/test/TestRefers.scala
+++ b/command/src/main/scala/scalaclean/test/TestRefers.scala
@@ -6,7 +6,7 @@ import scalaclean.model._
  * A rule use to test that internal incoming references are set correctly,
  * needs to be run after TestAnalysis
  */
-class Test_internalIncomingReferences(model: ProjectModel)
+class Test_internalIncomingReferences(model: AllProjectsModel)
     extends TestCommon("Test_internalIncomingReferences", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
@@ -19,7 +19,7 @@ class Test_internalIncomingReferences(model: ProjectModel)
  * A rule use to test that internal outgoing references are set correctly,
  * needs to be run after TestAnalysis
  */
-class Test_internalOutgoingReferences(model: ProjectModel)
+class Test_internalOutgoingReferences(model: AllProjectsModel)
     extends TestCommon("Test_internalOutgoingReferences", model) {
 
   override def visitInSource(modelElement: ModelElement): String = {
@@ -33,7 +33,7 @@ class Test_internalOutgoingReferences(model: ProjectModel)
  * A rule use to test that internal and external outgoing references ar set correctly,
  * needs to be run after TestAnalysis
  */
-class Test_allOutgoingReferences(model: ProjectModel) extends TestCommon("Test_allOutgoingReferences", model) {
+class Test_allOutgoingReferences(model: AllProjectsModel) extends TestCommon("Test_allOutgoingReferences", model) {
 
   override def visitInSource(modelElement: ModelElement): String =
     elementIdsTestFormat("allOutgoingReferences", modelElement,

--- a/command/src/main/scala/scalaclean/util/DiffAssertions.scala
+++ b/command/src/main/scala/scalaclean/util/DiffAssertions.scala
@@ -40,17 +40,11 @@ trait DiffAssertions {
       diff: String
   ) extends Exception
 
-  def error2message(obtained: String, expected: String): String = {
+  def error2message(diff: String): String = {
     val sb = new StringBuilder
-    if (obtained.length < 1000) {
-      sb.append(s"""
-                   #${header("Obtained")}
-                   #${trailingSpace(obtained)}
-         """.stripMargin('#'))
-    }
     sb.append(s"""
                  #${header("Diff")}
-                 #${trailingSpace(compareContents(obtained, expected))}
+                 #${trailingSpace(diff)}
          """.stripMargin('#'))
     sb.toString()
   }

--- a/command/src/main/scala/scalaclean/util/ScalaCleanTreePatcher.scala
+++ b/command/src/main/scala/scalaclean/util/ScalaCleanTreePatcher.scala
@@ -1,6 +1,7 @@
 package scalaclean.util
 
-import scalaclean.model.{ ModelElement, SCPatch, SourceModel }
+import scalaclean.cli.ScalaCleanCommandLine
+import scalaclean.model.{ModelElement, SCPatch, SourceModel}
 import scalaclean.rules.SourceFile
 import scalafix.v1.SyntacticDocument
 
@@ -13,7 +14,8 @@ import scala.collection.mutable.ListBuffer
  *
  * It has default handling of source files and non source elements
  */
-abstract class ScalaCleanTreePatcher(sourceFile: SourceFile) extends ElementTreeVisitor {
+abstract class ScalaCleanTreePatcher[O <: ScalaCleanCommandLine](sourceFile: SourceFile, options: O)
+  extends ElementTreeVisitor[O](sourceFile, options) {
 
   protected def syntacticDocument: SyntacticDocument = sourceFile.syntacticDocument
   def tokenArray = sourceFile.tokenArray
@@ -23,8 +25,6 @@ abstract class ScalaCleanTreePatcher(sourceFile: SourceFile) extends ElementTree
   protected def visitNotInSource(modelElement: ModelElement) = true
 
   protected def visitInSource(modelElement: ModelElement): Boolean
-  def debug: Boolean
-  def addComments: Boolean
 
   override protected final def visitElement(modelElement: ModelElement): Boolean = {
     elementsVisited += 1

--- a/tests/src/main/scala/scalaclean/cli/AbstractProjectTestRunner.scala
+++ b/tests/src/main/scala/scalaclean/cli/AbstractProjectTestRunner.scala
@@ -3,7 +3,7 @@ package scalaclean.cli
 import java.io.File
 import java.nio.file.{Files, Path, Paths}
 
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.model.impl.ProjectSet
 import scalaclean.rules.RuleRun
 import scalaclean.util.DiffAssertions
@@ -17,7 +17,7 @@ abstract class AbstractProjectTestRunner[Cmd <: ScalaCleanCommandLine: ClassTag,
     extends DiffAssertions with Assertions{
 
   def cmdLine: Cmd = classTag[Cmd].runtimeClass.newInstance().asInstanceOf[Cmd]
-  def rule(cmd: Cmd, model: ProjectModel): Rule
+  def rule(cmd: Cmd, model: AllProjectsModel): Rule
 
   def customise(options: Cmd): Unit = ()
 

--- a/tests/src/test/scala/scalaclean/BrokenPrivatiserTests.scala
+++ b/tests/src/test/scala/scalaclean/BrokenPrivatiserTests.scala
@@ -2,14 +2,14 @@ package scalaclean.broken
 
 import scalaclean.AbstractProjectTests
 import scalaclean.cli.{AbstractProjectTestRunner, ScalaCleanCommandLine, SimpleRunOptions}
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.rules.privatiser.{FullPrivatiser, FullPrivatiserCommandLine, SimplePrivatiser, SimplePrivatiserCommandLine}
 
 
 class BrokenFullPrivatiserTests extends BrokenPrivatiserTests {
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[FullPrivatiserCommandLine, FullPrivatiser](projectNames, options) {
-      override def rule(cmd: FullPrivatiserCommandLine, model: ProjectModel)= new FullPrivatiser(cmd, model)
+      override def rule(cmd: FullPrivatiserCommandLine, model: AllProjectsModel)= new FullPrivatiser(cmd, model)
       override val expectationSuffix = ".full"
     }
     tester.run()
@@ -24,7 +24,7 @@ class BrokenFullPrivatiserNoDupTests extends BrokenPrivatiserTests {
         options.reduceDuplicateScopeChanges = true
       }
 
-      override def rule(cmd: FullPrivatiserCommandLine, model: ProjectModel)= new FullPrivatiser(cmd, model)
+      override def rule(cmd: FullPrivatiserCommandLine, model: AllProjectsModel)= new FullPrivatiser(cmd, model)
       override val expectationSuffix = ".full-reduceDuplicate"
     }
     tester.run()
@@ -35,7 +35,7 @@ class BrokenSimplePrivatiserTests extends BrokenPrivatiserTests {
 
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[SimplePrivatiserCommandLine, SimplePrivatiser](projectNames, options) {
-      override def rule(cmd: SimplePrivatiserCommandLine, model: ProjectModel)= new SimplePrivatiser(cmd, model)
+      override def rule(cmd: SimplePrivatiserCommandLine, model: AllProjectsModel)= new SimplePrivatiser(cmd, model)
       override val expectationSuffix: String = ".simple"
     }
     tester.run()
@@ -52,7 +52,7 @@ class BrokenSimplePrivatiserNoDupTests extends BrokenPrivatiserTests {
         options.reduceDuplicateScopeChanges = true
       }
 
-      override def rule(cmd: SimplePrivatiserCommandLine, model: ProjectModel)= new SimplePrivatiser(cmd, model)
+      override def rule(cmd: SimplePrivatiserCommandLine, model: AllProjectsModel)= new SimplePrivatiser(cmd, model)
       override val expectationSuffix: String = ".simple-reduceDuplicate"
     }
     tester.run()
@@ -64,7 +64,7 @@ abstract class BrokenPrivatiserTests extends AbstractProjectTests {
 
     override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
       object tester extends AbstractProjectTestRunner[FullPrivatiserCommandLine, FullPrivatiser](projectNames, options) {
-        override def rule(cmd: FullPrivatiserCommandLine, model: ProjectModel)= new FullPrivatiser(cmd, model)
+        override def rule(cmd: FullPrivatiserCommandLine, model: AllProjectsModel)= new FullPrivatiser(cmd, model)
         val expectationSuffix: String = ""
       }
       tester.run()

--- a/tests/src/test/scala/scalaclean/DeadCodeTests.scala
+++ b/tests/src/test/scala/scalaclean/DeadCodeTests.scala
@@ -1,14 +1,13 @@
 package scalaclean
 
-import org.scalatest.Ignore
 import scalaclean.cli.{AbstractProjectTestRunner, SimpleRunOptions}
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.rules.deadcode.{FullDeadCodeCommandLine, FullDeadCodeRemover, SimpleDeadCodeCommandLine, SimpleDeadCodeRemover}
 
 class FullDeadCodeTests extends BaseDeadCodeTests {
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[FullDeadCodeCommandLine, FullDeadCodeRemover](projectNames, options) {
-      override def rule(cmd: FullDeadCodeCommandLine, model: ProjectModel)= new FullDeadCodeRemover(cmd, model)
+      override def rule(cmd: FullDeadCodeCommandLine, model: AllProjectsModel)= new FullDeadCodeRemover(cmd, model)
       override val expectationSuffix = ".full"
     }
     tester.run()
@@ -19,7 +18,7 @@ class SimpleDeadCodeTests extends BaseDeadCodeTests {
 
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[SimpleDeadCodeCommandLine, SimpleDeadCodeRemover](projectNames, options) {
-      override def rule(cmd: SimpleDeadCodeCommandLine, model: ProjectModel)= new SimpleDeadCodeRemover(cmd, model)
+      override def rule(cmd: SimpleDeadCodeCommandLine, model: AllProjectsModel)= new SimpleDeadCodeRemover(cmd, model)
       override val expectationSuffix: String = ".simple"
     }
     tester.run()

--- a/tests/src/test/scala/scalaclean/FinaliserTests.scala
+++ b/tests/src/test/scala/scalaclean/FinaliserTests.scala
@@ -1,14 +1,14 @@
 package scalaclean
 
 import scalaclean.cli.{AbstractProjectTestRunner, ScalaCleanCommandLine, SimpleRunOptions}
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.rules.deadcode.{SimpleDeadCodeCommandLine, SimpleDeadCodeRemover}
 import scalaclean.rules.finaliser.{Finaliser, FinaliserCommandLine}
 
 class FinaliserTests extends AbstractProjectTests {
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[FinaliserCommandLine, Finaliser](projectNames, options) {
-      override def rule(cmd: FinaliserCommandLine, model: ProjectModel)= new Finaliser(cmd, model)
+      override def rule(cmd: FinaliserCommandLine, model: AllProjectsModel)= new Finaliser(cmd, model)
       override val expectationSuffix: String = ""
     }
     tester.run()

--- a/tests/src/test/scala/scalaclean/PrivatiserTests.scala
+++ b/tests/src/test/scala/scalaclean/PrivatiserTests.scala
@@ -1,14 +1,14 @@
 package scalaclean
 
 import scalaclean.cli.{AbstractProjectTestRunner, ScalaCleanCommandLine, SimpleRunOptions}
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.rules.privatiser.{FullPrivatiser, FullPrivatiserCommandLine, SimplePrivatiser, SimplePrivatiserCommandLine}
 
 
 class FullPrivatiserTests extends BasePrivatiserTests {
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[FullPrivatiserCommandLine, FullPrivatiser](projectNames, options) {
-      override def rule(cmd: FullPrivatiserCommandLine, model: ProjectModel)= new FullPrivatiser(cmd, model)
+      override def rule(cmd: FullPrivatiserCommandLine, model: AllProjectsModel)= new FullPrivatiser(cmd, model)
       override val expectationSuffix = ".full"
     }
     tester.run()
@@ -23,7 +23,7 @@ class FullPrivatiserNoDupTests extends BasePrivatiserTests {
         options.reduceDuplicateScopeChanges = true
       }
 
-      override def rule(cmd: FullPrivatiserCommandLine, model: ProjectModel)= new FullPrivatiser(cmd, model)
+      override def rule(cmd: FullPrivatiserCommandLine, model: AllProjectsModel)= new FullPrivatiser(cmd, model)
       override val expectationSuffix = ".full-reduceDuplicate"
     }
     tester.run()
@@ -34,7 +34,7 @@ class SimplePrivatiserTests extends BasePrivatiserTests {
 
   override def projectsTest(projectNames: List[String], options: SimpleRunOptions): Unit = {
     object tester extends AbstractProjectTestRunner[SimplePrivatiserCommandLine, SimplePrivatiser](projectNames, options) {
-      override def rule(cmd: SimplePrivatiserCommandLine, model: ProjectModel)= new SimplePrivatiser(cmd, model)
+      override def rule(cmd: SimplePrivatiserCommandLine, model: AllProjectsModel)= new SimplePrivatiser(cmd, model)
       override val expectationSuffix: String = ".simple"
     }
     tester.run()
@@ -51,7 +51,7 @@ class SimplePrivatiserNoDupTests extends BasePrivatiserTests {
         options.reduceDuplicateScopeChanges = true
       }
 
-      override def rule(cmd: SimplePrivatiserCommandLine, model: ProjectModel)= new SimplePrivatiser(cmd, model)
+      override def rule(cmd: SimplePrivatiserCommandLine, model: AllProjectsModel)= new SimplePrivatiser(cmd, model)
       override val expectationSuffix: String = ".simple-reduceDuplicate"
     }
     tester.run()

--- a/tests/src/test/scala/scalaclean/UnitTests.scala
+++ b/tests/src/test/scala/scalaclean/UnitTests.scala
@@ -8,7 +8,7 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.{BeforeAndAfterAllConfigMap, ConfigMap}
 import org.scalatestplus.junit.AssertionsForJUnit
 import scalaclean.cli.SCPatchUtil
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.model.impl.ProjectSet
 import scalaclean.test._
 import scalaclean.util.DiffAssertions
@@ -21,7 +21,7 @@ trait AbstractUnitTests extends AnyFunSuite with AssertionsForJUnit with DiffAss
     overwrite = configMap.getWithDefault("overwrite", "false").equalsIgnoreCase("true")
   }
 
-  def runTest(file: String, ruleFn: ProjectModel => TestCommon, expectationSuffix: String = "", overwrite: Boolean = false): Unit = {
+  def runTest(file: String, ruleFn: AllProjectsModel => TestCommon, expectationSuffix: String = "", overwrite: Boolean = false): Unit = {
     val scalaCleanWorkspace = if (Files.exists(Paths.get("../testProjects"))) {
       Paths.get("..").toAbsolutePath.toRealPath()
     } else {
@@ -47,7 +47,7 @@ trait AbstractUnitTests extends AnyFunSuite with AssertionsForJUnit with DiffAss
       SCPatchUtil.applyFixes(origDocContents, patches)
     }
 
-    def runRule(projectModel: ProjectModel): Unit = {
+    def runRule(projectModel: AllProjectsModel): Unit = {
 
       println("---------------------------------------------------------------------------------------------------")
       // run rule
@@ -77,7 +77,7 @@ trait AbstractUnitTests extends AnyFunSuite with AssertionsForJUnit with DiffAss
           println("###########> expected       <###########")
           println(expected)
           println("###########> Diff       <###########")
-          println(error2message(obtained, expected))
+          println(error2message(diff))
 
           fail("Differences detected, see diff above")
         }

--- a/tests/src/test/scala/scalaclean/unit/ExtendsTests.scala
+++ b/tests/src/test/scala/scalaclean/unit/ExtendsTests.scala
@@ -2,7 +2,7 @@ package scalaclean.unit
 
 import org.scalatestplus.junit.AssertionsForJUnit
 import scalaclean.AbstractUnitTests
-import scalaclean.model.ProjectModel
+import scalaclean.model.AllProjectsModel
 import scalaclean.test.{Test_extendedBy, Test_extends, Test_extendsCompiled}
 
 object ExtendsTests {
@@ -11,7 +11,7 @@ object ExtendsTests {
 }
 class ExtendsTests extends AbstractUnitTests with AssertionsForJUnit {
 
-  def doRun(test: ProjectModel => Test_extends, suffix: String): Unit = {
+  def doRun(test: AllProjectsModel => Test_extends, suffix: String): Unit = {
     runTest(ExtendsTests.src,
       test,
       expectationSuffix = s".extends.$suffix",
@@ -52,7 +52,7 @@ class ExtendsTests extends AbstractUnitTests with AssertionsForJUnit {
 
 class ExtendsCompiledTests extends AbstractUnitTests {
 
-  def doRun(test: ProjectModel => Test_extendsCompiled, suffix: String): Unit = {
+  def doRun(test: AllProjectsModel => Test_extendsCompiled, suffix: String): Unit = {
     runTest(ExtendsTests.src,
       test,
       expectationSuffix = s".extends-compiled.$suffix",
@@ -93,7 +93,7 @@ class ExtendsCompiledTests extends AbstractUnitTests {
 
 class ExtendedByTests extends AbstractUnitTests {
 
-  def doRun(test: ProjectModel => Test_extendedBy, suffix: String): Unit = {
+  def doRun(test: AllProjectsModel => Test_extendedBy, suffix: String): Unit = {
     runTest(ExtendsTests.src,
       test,
       expectationSuffix = s".extendedBy.$suffix",


### PR DESCRIPTION
Add more data to SourceModel (length and hash)
Optionally store the compiled source in a jar alongside the properties (copySources:true)

add analysis flag (--sourceValidation) to validate the sources against what was compiled

add analysis flag (--externalInterface) to indicate that the source is called by things outside he model, e.g. java code
update rules to take this into account

add analysis flag (--generatedSource) to indicate that the source is generated
update rules to take this into account

add navigation from a ModelElement to a SingleProjectModel that it is part of
add navigation from a SingleProjectModel to AllProjectsModel
add navigation from a AllProjectsModel to SingleProjectModel
add navigation from a SourceModel to the source that was compile if it was stored

make the rule treewalker aware of the command  line options