### PR TITLE
rework overrides relationship navigation

### DIFF
--- a/command/src/main/scala/scalaclean/model/References.scala
+++ b/command/src/main/scala/scalaclean/model/References.scala
@@ -74,6 +74,10 @@ sealed trait Within extends Reference
 trait ExtendsReference         extends ExternalElementReference[ClassLike] with HasIsDirect
 trait ExtendsInternalReference extends InternalElementReference[ClassLike] with HasIsDirect
 trait ExtendedByReference      extends InternalElementReference[ClassLike] with HasIsDirect
+
+trait OverridesReference         extends ExternalElementReference[ModelElement] with HasIsDirect with HasIsSynthetic
+trait OverridesInternalReference extends InternalElementReference[ModelElement] with HasIsDirect with HasIsSynthetic
+trait OverriddenByReference      extends InternalElementReference[ModelElement] with HasIsDirect with HasIsSynthetic
 //end concrete relationship results from model APIs
 
 package impl {
@@ -137,12 +141,12 @@ package impl {
 
   final class OverridesImpl(from: ElementId, to: ElementId, val isDirect: Boolean, val isSynthetic: Boolean)
   //maybe should be Member, Member
-      extends ReferenceImpl[ModelElement, ModelElement](from, to)
+      extends ReferenceImpl[ElementModelImpl, ElementModelImpl](from, to)
       with Overrides {
 
-    override def clsFrom: Class[ModelElement] = classOf[ModelElement]
+    override def clsFrom: Class[ElementModelImpl] = classOf[ElementModelImpl]
 
-    override def clsTo: Class[ModelElement] = classOf[ModelElement]
+    override def clsTo: Class[ElementModelImpl] = classOf[ElementModelImpl]
 
     override def toString: String = s"Overrides($from -> $to, isDirect = $isDirect, isSynthetic = $isSynthetic"
   }

--- a/command/src/main/scala/scalaclean/model/impl/Caches.scala
+++ b/command/src/main/scala/scalaclean/model/impl/Caches.scala
@@ -11,4 +11,10 @@ private[impl] object Caches {
   private val xtendsCache = new ConcurrentHashMap[(ElementId, ClassLikeImpl), Boolean]
   def xtends(symbol: ElementId, cls: ClassLikeImpl): Boolean =
     xtendsCache.computeIfAbsent((symbol, cls), x => x._2.extendsElementId(filter = Some(_.elementId == x._1)).hasNext)
+
+  //TODO should probably be a Member
+  private val overridesExternalCache = new ConcurrentHashMap[ElementModelImpl, Boolean]
+  def overridesExternal(ele: ElementModelImpl): Boolean =
+    overridesExternalCache.computeIfAbsent(ele, m => m.overridesFull().exists( _.elementIfDefined.fold(true)(_.overridesExternal)))
+
 }

--- a/command/src/main/scala/scalaclean/rules/deadcode/AbstractDeadCodeRemover.scala
+++ b/command/src/main/scala/scalaclean/rules/deadcode/AbstractDeadCodeRemover.scala
@@ -137,12 +137,12 @@ abstract class AbstractDeadCodeRemover[T <: AbstractDeadCodeCommandLine] extends
     //overrides
     //TODO should probably mark the definition as used only here
     // as the method/class could be abstract, or maybe thats a different rule
-    element.internalTransitiveOverrides.foreach { enclosed =>
+    element.overridesElement().foreach { enclosed =>
       markUsed(enclosed, markEnclosing = true, purpose, pathWithElement, comment_overrides)
     }
 
     //overridden by
-    element.internalTransitiveOverriddenBy.foreach { enclosed =>
+    element.overriddenByElement().foreach { enclosed =>
       markUsed(enclosed, markEnclosing = false, purpose.withoutClass, pathWithElement, comment_overridden)
     }
     element match {
@@ -229,7 +229,7 @@ abstract class AbstractDeadCodeRemover[T <: AbstractDeadCodeCommandLine] extends
     }
     allScalaTests.foreach(e => markEntryUsed(e, markEnclosing = true, Test, e, "scalatests"))
 
-    model.allOf[MethodModel].filter(_.allTransitiveOverrides.exists(_._1.isEmpty)) foreach {e =>
+    (model.allOf[MethodModel] ++ model.allOf[FieldModel]).filter(_.overridesExternal) foreach {e =>
       markEntryUsed(e, markEnclosing = false, MainNotClass, e, "external API implementation/override")
     }
 

--- a/command/src/main/scala/scalaclean/rules/finaliser/Finaliser.scala
+++ b/command/src/main/scala/scalaclean/rules/finaliser/Finaliser.scala
@@ -123,8 +123,7 @@ class Finaliser(override val options: FinaliserCommandLine, override val model: 
       case cls: ClassModel if localLevel(cls).specific.contains(Final) => dontChangeBecause.ownerIsFinalClass
       case cls: ObjectModel                            => dontChangeBecause.ownerIsObject
       case cls: ClassLike =>
-        val overrides = method.overridden
-        if (overrides.isEmpty) changeTo.makeFinal
+        if (method.overriddenByElement().isEmpty) changeTo.makeFinal
         else changeTo.keepOpen
       case encl => dontChange(s"enclosed in $encl")
     }
@@ -139,12 +138,13 @@ class Finaliser(override val options: FinaliserCommandLine, override val model: 
       case cls: ClassLike                                  =>
         // we need to consider the accessors. The val isn't overridden, but if the accessor is then we cant make it final
         // in the parent
-        val overrides: Iterable[Overrides] = field.overridden ++ field.accessors.flatMap(_.overridden)
+        val overrides = field.overriddenByElement() ++ field.accessors.flatMap(_.overriddenByElement())
         if (overrides.isEmpty)
           changeTo.makeFinal
         else {
-          val size = overrides.size
-          dontChange(s"$size overrides - e.g. ${overrides.head.fromElementId}")
+          val first = overrides.next
+          val size = overrides.size + 1
+          dontChange(s"$size overrides - e.g. ${first}")
         }
       case encl => dontChange(s"enclosed in $encl")
     }

--- a/command/src/main/scala/scalaclean/rules/privatiser/PrivatiserLevel.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/PrivatiserLevel.scala
@@ -116,7 +116,7 @@ private[privatiser] final case class Scoped(
 
     def referencedInSubclass: Boolean = context match {
       case classLike: ClassLike => !classLike.extendedByElement().isEmpty
-      case _                    => !context.overridden.isEmpty
+      case _                    => !context.overriddenByElement().isEmpty
     }
     //we dont need to label elements private if the enclosing class is private, or more restrictive
     //unless things inherit from this

--- a/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
@@ -13,21 +13,12 @@ object SimplePrivatiser extends AbstractRule[SimplePrivatiserCommandLine] {
 class SimplePrivatiser(options: SimplePrivatiserCommandLine, model: AllProjectsModel)
     extends AbstractPrivatiser(options, model) {
 
-
-  def isOverridden(e: ModelElement): Boolean = {
-    e.internalTransitiveOverriddenBy.nonEmpty
-  }
-
-  def isOverrides(e: ModelElement): Boolean = {
-    e.allTransitiveOverrides.nonEmpty
-  }
-
   override def ruleSpecific(): Unit = {
     model.allOf[ModelElement].foreach {
-      case e if isOverridden(e) =>
-        e.colour = dontChange(s"It's overridden ${e.internalTransitiveOverriddenBy.head}")
-      case e if isOverrides(e) =>
-        e.colour = dontChange(s"It overrides ${e.allTransitiveOverrides.head}")
+      case e if e.overriddenByElement().nonEmpty =>
+        e.colour = dontChange(s"It's overridden ${e.overriddenByElement().next}")
+      case e if e.overridesElementId().nonEmpty =>
+        e.colour = dontChange(s"It overrides ${e.overridesElementId().next}")
       case e => e.colour = localLevel(e)
     }
   }

--- a/command/src/main/scala/scalaclean/test/TestCommon.scala
+++ b/command/src/main/scala/scalaclean/test/TestCommon.scala
@@ -22,9 +22,10 @@ abstract class TestCommon(name: String, model: AllProjectsModel) extends TestBas
    */
   def visitInSource(modelElement: ModelElement): String
 
-  def elementAndIdsInTestFormat(test: String, focus: ModelElement, elements: Iterator[(Option[ModelElement], ElementId)]): String = {
-    val strings = elements.map {
-      case (clOpt, elementId) =>
+  def elementAndIdsInTestFormat(test: String, focus: ModelElement, elements: Iterator[ExternalElementReference[_ <: ModelElement]]): String = {
+    val strings = elements.map { r =>
+      val clOpt = r.elementIfDefined
+      val elementId = r.elementId
         clOpt.foreach(cl =>
           assert(cl.modelElementId == elementId, s"cl.modelElementId(${cl.modelElementId}) != elementId($elementId)")
         )

--- a/command/src/main/scala/scalaclean/test/TestExtends.scala
+++ b/command/src/main/scala/scalaclean/test/TestExtends.scala
@@ -16,7 +16,7 @@ class Test_extends(
   override def visitInSource(modelElement: ModelElement): String = modelElement match {
     case classLike: ClassLike =>
       elementAndIdsInTestFormat("extends", modelElement,
-        classLike.extendsFull(directOnly, filter).map(e => (e.elementIfDefined, e.elementId)))
+        classLike.extendsFull(directOnly, filter))
     case _ => ""
   }
 

--- a/command/src/main/scala/scalaclean/test/TestInherits.scala
+++ b/command/src/main/scala/scalaclean/test/TestInherits.scala
@@ -7,7 +7,7 @@ class Test_internalDirectOverrides(model: AllProjectsModel) extends TestCommon("
 
   override def visitInSource(modelElement: ModelElement): String =
     elementsInTestFormat("internalDirectOverrides", modelElement,
-      modelElement.internalDirectOverrides)
+      modelElement.overridesElement(direct = Some(true)))
 
 }
 
@@ -17,7 +17,7 @@ class Test_internalTransitiveOverrides(model: AllProjectsModel)
 
   override def visitInSource(modelElement: ModelElement): String =
     elementsInTestFormat("internalTransitiveOverrides", modelElement,
-      modelElement.internalTransitiveOverrides)
+      modelElement.overridesElement())
 }
 
 /** A rule use to test the that overrides as set correctly */
@@ -25,7 +25,7 @@ class Test_allDirectOverrides(model: AllProjectsModel) extends TestCommon("Test_
 
   override def visitInSource(modelElement: ModelElement): String =
     elementAndIdsInTestFormat("allDirectOverrides", modelElement,
-      modelElement.allDirectOverrides.iterator)
+      modelElement.overridesFull(direct=Some(true)))
 }
 
 /** A rule use to test the that overrides as set correctly */
@@ -33,7 +33,7 @@ class Test_allTransitiveOverrides(model: AllProjectsModel) extends TestCommon("T
 
   override def visitInSource(modelElement: ModelElement): String =
     elementAndIdsInTestFormat("allTransitiveOverrides", modelElement,
-      modelElement.allTransitiveOverrides.iterator)
+      modelElement.overridesFull())
 }
 
 /** A rule use to test the that overrides as set correctly */
@@ -42,7 +42,7 @@ class Test_internalDirectOverriddenBy(model: AllProjectsModel)
 
   override def visitInSource(modelElement: ModelElement): String =
     elementsInTestFormat("internalDirectOverriddenBy", modelElement,
-      modelElement.internalDirectOverriddenBy)
+      modelElement.overriddenByElement(direct = Some(true)))
 
 }
 
@@ -52,6 +52,6 @@ class Test_internalTransitiveOverriddenBy(model: AllProjectsModel)
 
   override def visitInSource(modelElement: ModelElement): String =
     elementsInTestFormat("internalTransitiveOverriddenBy", modelElement,
-      modelElement.internalTransitiveOverriddenBy)
+      modelElement.overriddenByElement())
 
 }


### PR DESCRIPTION
from https://github.com/rorygraves/ScalaClean/issues/112


- [x] overrides
(some of)
delete legacy APIs
use Iterator rather that concrete collections in the more API to avoid hydrating collections