### PR TITLE
rework refers relationship APIs

### DIFF
--- a/command/src/main/scala/scalaclean/model/References.scala
+++ b/command/src/main/scala/scalaclean/model/References.scala
@@ -78,6 +78,10 @@ trait ExtendedByReference      extends InternalElementReference[ClassLike] with 
 trait OverridesReference         extends ExternalElementReference[ModelElement] with HasIsDirect with HasIsSynthetic
 trait OverridesInternalReference extends InternalElementReference[ModelElement] with HasIsDirect with HasIsSynthetic
 trait OverriddenByReference      extends InternalElementReference[ModelElement] with HasIsDirect with HasIsSynthetic
+
+trait RefersToReference          extends ExternalElementReference[ModelElement] with HasIsSynthetic
+trait RefersToInternalReference  extends InternalElementReference[ModelElement] with HasIsSynthetic
+trait ReferredToByReference      extends InternalElementReference[ModelElement] with HasIsSynthetic
 //end concrete relationship results from model APIs
 
 package impl {
@@ -119,10 +123,10 @@ package impl {
   }
 
   sealed abstract class ReferenceImplBase(from: ElementId, to: ElementId)
-      extends ReferenceImpl[ModelElement, ModelElement](from, to) {
-    override def clsFrom: Class[ModelElement] = classOf[ModelElement]
+      extends ReferenceImpl[ElementModelImpl, ElementModelImpl](from, to) {
+    override def clsFrom: Class[ElementModelImpl] = classOf[ElementModelImpl]
 
-    override def clsTo: Class[ModelElement] = classOf[ModelElement]
+    override def clsTo: Class[ElementModelImpl] = classOf[ElementModelImpl]
   }
 
   final class RefersImpl(from: ElementId, to: ElementId, val isSynthetic: Boolean)

--- a/command/src/main/scala/scalaclean/model/impl/RelationshipNavigation.scala
+++ b/command/src/main/scala/scalaclean/model/impl/RelationshipNavigation.scala
@@ -1,6 +1,6 @@
 package scalaclean.model.impl
 
-import scalaclean.model.{ClassLike, ElementId, ExtendedByReference, ExtendsInternalReference, ExtendsReference, HasIsDirect, HasIsSynthetic, ModelElement, NotNothing, OverriddenByReference, OverridesInternalReference, OverridesReference, Reference}
+import scalaclean.model._
 
 import scala.runtime.AbstractFunction1
 
@@ -73,28 +73,53 @@ private[impl] object RelationshipNavigation {
 
   //overrides relationship
   abstract class OverridesReferenceBaseFilter
-      extends RelsBaseFilter[OverridesImpl]
+    extends RelsBaseFilter[OverridesImpl]
       with RelsDirectFilter[OverridesImpl]
       with RelsSyntheticFilter[OverridesImpl]
 
   class OverridesReferenceFilter(f: OverridesReference => Boolean)
-      extends OverridesReferenceBaseFilter
+    extends OverridesReferenceBaseFilter
       with RelsToFilter[ElementModelImpl, ElementModelImpl, OverridesImpl]
       with OverridesReference {
     override def applyImpl: Boolean = f(this)
   }
 
   class OverridesInternalReferenceFilter(f: OverridesInternalReference => Boolean)
-      extends OverridesReferenceBaseFilter
+    extends OverridesReferenceBaseFilter
       with RelsToInternalFilter[ElementModelImpl, ElementModelImpl, OverridesImpl]
       with OverridesInternalReference {
     override def applyImpl: Boolean = f(this)
   }
 
   class OverriddenByReferenceFilter(f: OverriddenByReference => Boolean)
-      extends OverridesReferenceBaseFilter
+    extends OverridesReferenceBaseFilter
       with RelsFromFilter[ElementModelImpl, ElementModelImpl, OverridesImpl]
       with OverriddenByReference {
+    override def applyImpl: Boolean = f(this)
+  }
+  //refers relationship
+  abstract class RefersReferenceBaseFilter
+    extends RelsBaseFilter[RefersImpl]
+      with RelsSyntheticFilter[RefersImpl]
+
+  class RefersToReferenceFilter(f: RefersToReference => Boolean)
+    extends RefersReferenceBaseFilter
+      with RelsToFilter[ElementModelImpl, ElementModelImpl, RefersImpl]
+      with RefersToReference {
+    override def applyImpl: Boolean = f(this)
+  }
+
+  class RefersToInternalReferenceFilter(f: RefersToInternalReference => Boolean)
+    extends RefersReferenceBaseFilter
+      with RelsToInternalFilter[ElementModelImpl, ElementModelImpl, RefersImpl]
+      with RefersToInternalReference {
+    override def applyImpl: Boolean = f(this)
+  }
+
+  class ReferredToByReferenceFilter(f: ReferredToByReference => Boolean)
+    extends RefersReferenceBaseFilter
+      with RelsFromFilter[ElementModelImpl, ElementModelImpl, RefersImpl]
+      with ReferredToByReference {
     override def applyImpl: Boolean = f(this)
   }
 
@@ -155,6 +180,21 @@ private[impl] object RelationshipNavigation {
 
     def to(e: OverridesImpl): OverridesReference      = new OverridesReferenceData(e)
     def from(e: OverridesImpl): OverriddenByReference = new OverriddenByReferenceData(e)
+
+    class RefersToReferenceData(e: RefersImpl)
+      extends RelsBase[RefersImpl](e)
+        with RelsSynthetic[RefersImpl]
+        with RelsTo[ElementModelImpl, ElementModelImpl, RefersImpl]
+        with RefersToReference
+
+    class ReferredToByReferenceData(e: RefersImpl)
+      extends RelsBase[RefersImpl](e)
+        with RelsSynthetic[RefersImpl]
+        with RelsFrom[ElementModelImpl, ElementModelImpl, RefersImpl]
+        with ReferredToByReference
+
+    def to(e: RefersImpl): RefersToReference       = new RefersToReferenceData(e)
+    def from(e: RefersImpl): ReferredToByReference = new ReferredToByReferenceData(e)
   }
 
 }

--- a/command/src/main/scala/scalaclean/rules/deadcode/AbstractDeadCodeRemover.scala
+++ b/command/src/main/scala/scalaclean/rules/deadcode/AbstractDeadCodeRemover.scala
@@ -51,20 +51,20 @@ abstract class AbstractDeadCodeRemover[T <: AbstractDeadCodeCommandLine] extends
     element.fields.foreach {
       case valDef: ValModel =>
         if (!valDef.isLazy) {
-          valDef.internalOutgoingReferences.foreach { case (ref, _) =>
+          valDef.refersToElement().foreach { ref =>
             markUsed(ref, markEnclosing = true, purpose, valDef :: path, comment_valDefO)
           }
           markRhs(valDef, purpose, valDef :: path, comment_valDef)
         }
       case varDef: VarModel =>
-        varDef.internalOutgoingReferences.foreach { case (ref, _) =>
+        varDef.refersToElement().foreach { ref =>
           markUsed(ref, markEnclosing = true, purpose, varDef :: path, comment_varDefO)
         }
         markRhs(varDef, purpose, varDef :: path, comment_varDef)
       //TODO - not sure if this is correct
       // an inner object is lazy in scala, so probably should only be marked when used
       case obj: ObjectModel =>
-        obj.internalOutgoingReferences.foreach { case (ref, _) =>
+        obj.refersToElement().foreach { ref =>
           markUsed(ref, markEnclosing = true, purpose, obj :: path, comment_objO)
         }
         markRhs(obj, purpose, obj :: path, comment_obj)
@@ -115,7 +115,7 @@ abstract class AbstractDeadCodeRemover[T <: AbstractDeadCodeCommandLine] extends
     lazy val comment_fields = "fields" :: comment
 
     //all the elements that this refers to
-    element.internalOutgoingReferences.foreach { case (ref, _) =>
+    element.refersToElement().foreach { ref =>
       markUsed(ref, markEnclosing = true, purpose, pathWithElement, comment_internalOutgoingReferences)
     }
 

--- a/command/src/main/scala/scalaclean/rules/deadcode/SimpleDeadCodeRemover.scala
+++ b/command/src/main/scala/scalaclean/rules/deadcode/SimpleDeadCodeRemover.scala
@@ -64,7 +64,7 @@ class SimpleDeadCodeRemover(override val options: SimpleDeadCodeCommandLine, ove
           fieldsModel.fieldsInDeclaration.flatMap(incomingReferences)
         case _ => Nil
       }
-      val refs = thisElement.internalIncomingReferences.map(_._1).iterator ++ extra
+      val refs = thisElement.referredToByElement() ++ extra
       refs.filterNot(tried).foreach {
         case e1 if e1.existsInSource && !encloses(e1) =>
           simpleMarkUsed(element, e1.modelElementId, "references")

--- a/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
+++ b/command/src/main/scala/scalaclean/rules/privatiser/SimplePrivatiser.scala
@@ -23,14 +23,13 @@ class SimplePrivatiser(options: SimplePrivatiserCommandLine, model: AllProjectsM
     }
   }
 
-  override def determineAccess(element: ModelElement, myClassLike: ElementId, incomingReferences: Iterable[Refers]): Colour = {
+  override def determineAccess(element: ModelElement, myClassLike: ElementId, incomingReferences: Iterator[ModelElement]): Colour = {
     val myId = element.modelElementId
 
     var refFromContainer: ModelElement = null
     var refFromCompanion: ModelElement = null
     var refFromOutside: ModelElement   = null
-    incomingReferences.foreach { ref =>
-      val from = ref.fromElement
+    incomingReferences.foreach { from =>
       if (from.modelElementId.equalsOrHasParent(myId)) {
         if (debug)
           println("internal reference can be ignored")

--- a/command/src/main/scala/scalaclean/test/TestRefers.scala
+++ b/command/src/main/scala/scalaclean/test/TestRefers.scala
@@ -11,7 +11,7 @@ class Test_internalIncomingReferences(model: AllProjectsModel)
 
   override def visitInSource(modelElement: ModelElement): String =
     elementsInTestFormat("internalIncomingReferences", modelElement,
-      modelElement.internalIncomingReferences.map(_._1))
+      modelElement.referredToByElement())
 
 }
 
@@ -24,7 +24,7 @@ class Test_internalOutgoingReferences(model: AllProjectsModel)
 
   override def visitInSource(modelElement: ModelElement): String = {
     elementsInTestFormat("internalOutgoingReferences", modelElement,
-      modelElement.internalOutgoingReferences.map(_._1))
+      modelElement.refersToElement())
   }
 
 }
@@ -37,6 +37,6 @@ class Test_allOutgoingReferences(model: AllProjectsModel) extends TestCommon("Te
 
   override def visitInSource(modelElement: ModelElement): String =
     elementIdsTestFormat("allOutgoingReferences", modelElement,
-      modelElement.allOutgoingReferences.map(_._2.toElementId))
+      modelElement.refersToElementId())
 
 }


### PR DESCRIPTION
from https://github.com/rorygraves/ScalaClean/issues/112

-  [x] refers
 - [x] delete legacy APIs
 - [x] use Iterator rather that concrete collections in the more API to avoid hydrating collections